### PR TITLE
Revert on spending zero value

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -79,6 +79,9 @@ contract SpendPermissionManager is EIP712 {
     /// @notice Spend Permission has zero period.
     error ZeroPeriod();
 
+    /// @notice Attempting to spend zero value.
+    error ZeroValue();
+
     /// @notice Unauthorized spend permission.
     error UnauthorizedSpendPermission();
 
@@ -294,8 +297,8 @@ contract SpendPermissionManager is EIP712 {
     /// @param spendPermission Details of the spend permission.
     /// @param value Amount of token attempting to spend (wei).
     function _useSpendPermission(SpendPermission memory spendPermission, uint256 value) internal {
-        // early return if no value spent
-        if (value == 0) return;
+        // check value is non-zero
+        if (value == 0) revert ZeroValue();
 
         // require spend permission is approved and not revoked
         if (!isApproved(spendPermission)) revert UnauthorizedSpendPermission();

--- a/test/src/SpendPermissions/getCurrentPeriod.t.sol
+++ b/test/src/SpendPermissions/getCurrentPeriod.t.sol
@@ -87,6 +87,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
+        vm.assume(spend > 0);
         vm.assume(spend <= allowance);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -124,6 +125,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         vm.assume(period > 0);
         vm.assume(period <= end - start);
         vm.assume(allowance > 0);
+        vm.assume(spend > 0);
         vm.assume(spend <= allowance);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -163,6 +165,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         vm.assume(period > 0);
         vm.assume(period < end - start);
         vm.assume(allowance > 0);
+        vm.assume(spend > 0);
         vm.assume(spend <= allowance);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -51,6 +51,40 @@ contract SpendTest is SpendPermissionManagerBase {
         vm.stopPrank();
     }
 
+    function test_spend_revert_zeroValue(
+        uint128 invalidPk,
+        address spender,
+        address recipient,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        uint160 spend = 0;
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroValue.selector));
+        mockSpendPermissionManager.spend(spendPermission, recipient, spend);
+        vm.stopPrank();
+    }
+
     function test_spend_revert_unauthorizedSpendPermission(
         uint128 invalidPk,
         address spender,

--- a/test/src/SpendPermissions/useSpendPermission.t.sol
+++ b/test/src/SpendPermissions/useSpendPermission.t.sol
@@ -123,6 +123,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
+        vm.assume(firstSpend > 0);
         vm.assume(firstSpend < allowance);
         vm.assume(secondSpend > allowance - firstSpend);
         vm.assume(secondSpend < type(uint160).max - firstSpend);
@@ -153,10 +154,11 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         mockSpendPermissionManager.useSpendPermission(spendPermission, secondSpend);
     }
 
-    function test_useSpendPermission_success_noSpend() public {
+    function test_useSpendPermission_revert_zeroValue() public {
         SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermission();
         vm.prank(spendPermission.account);
         mockSpendPermissionManager.approve(spendPermission);
+        vm.expectRevert(SpendPermissionManager.ZeroValue.selector);
         mockSpendPermissionManager.useSpendPermission(spendPermission, 0);
     }
 


### PR DESCRIPTION
Allowing early return on zero spend value is a remnant of our Session Keys V1 where we would always call the function, irrespective if value was spent or not. This is no longer needed and it covers some small edge cases to just restrict non-zero value spends only.