### PR TITLE
[BW-428] Restricted ERC-6492 implementation specific factory call only

### DIFF
--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -56,6 +56,17 @@ contract SpendPermissionManagerBase is Base {
         uint256 ownerIndex,
         bytes[] memory allInitialOwners
     ) internal view returns (bytes memory) {
+        address factory = address(mockCoinbaseSmartWalletFactory);
+        return _signSpendPermission6492(spendPermission, factory, ownerPk, ownerIndex, allInitialOwners);
+    }
+
+    function _signSpendPermission6492(
+        SpendPermissionManager.SpendPermission memory spendPermission,
+        address factoryAddress,
+        uint256 ownerPk,
+        uint256 ownerIndex,
+        bytes[] memory allInitialOwners
+    ) internal view returns (bytes memory) {
         bytes32 spendPermissionHash = mockSpendPermissionManager.getHash(spendPermission);
         // construct replaySafeHash without relying on the account contract being deployed
         bytes32 cbswDomainSeparator = keccak256(
@@ -76,9 +87,8 @@ contract SpendPermissionManagerBase is Base {
         bytes memory wrappedSignature = _applySignatureWrapper(ownerIndex, signature);
 
         // wrap inner sig in 6492 format ======================
-        address factory = address(mockCoinbaseSmartWalletFactory);
         bytes memory factoryCallData = abi.encodeWithSignature("createAccount(bytes[],uint256)", allInitialOwners, 0);
-        bytes memory eip6492Signature = abi.encode(factory, factoryCallData, wrappedSignature);
+        bytes memory eip6492Signature = abi.encode(factoryAddress, factoryCallData, wrappedSignature);
         eip6492Signature = abi.encodePacked(eip6492Signature, EIP6492_MAGIC_VALUE);
         return eip6492Signature;
     }

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -18,8 +18,8 @@ contract SpendPermissionManagerBase is Base {
 
     function _initializeSpendPermissionManager() internal {
         _initialize(); // Base
-        mockSpendPermissionManager = new MockSpendPermissionManager();
         mockCoinbaseSmartWalletFactory = new CoinbaseSmartWalletFactory(address(account));
+        mockSpendPermissionManager = new MockSpendPermissionManager(mockCoinbaseSmartWalletFactory);
     }
 
     /**

--- a/test/mocks/MockSpendPermissionManager.sol
+++ b/test/mocks/MockSpendPermissionManager.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.23;
 
 import {SpendPermissionManager} from "../../src/SpendPermissionManager.sol";
+import {CoinbaseSmartWalletFactory} from "smart-wallet/CoinbaseSmartWalletFactory.sol";
 
 contract MockSpendPermissionManager is SpendPermissionManager {
+    constructor(CoinbaseSmartWalletFactory _factory) SpendPermissionManager(_factory) {}
+
     function useSpendPermission(SpendPermission memory spendPermission, uint256 value) public {
         _useSpendPermission(spendPermission, value);
     }

--- a/test/mocks/MockSpendPermissionManager.sol
+++ b/test/mocks/MockSpendPermissionManager.sol
@@ -10,4 +10,8 @@ contract MockSpendPermissionManager is SpendPermissionManager {
     function useSpendPermission(SpendPermission memory spendPermission, uint256 value) public {
         _useSpendPermission(spendPermission, value);
     }
+
+    function validateSignature(SpendPermission calldata spendPermission, bytes calldata signature) public {
+        _validateSignature(spendPermission, signature);
+    }
 }

--- a/test/src/SpendPermissions/Debug.t.sol
+++ b/test/src/SpendPermissions/Debug.t.sol
@@ -5,24 +5,22 @@ import {Test, console2} from "forge-std/Test.sol";
 
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
-import {Base} from "../../base/Base.sol";
+import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
 
-contract DebugTest is Test, Base {
-    address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-
+contract DebugTest is Test, SpendPermissionManagerBase {
     SpendPermissionManager spendPermissionManager;
 
     function setUp() public {
         _initialize();
 
-        spendPermissionManager = new SpendPermissionManager();
+        spendPermissionManager = new SpendPermissionManager(mockCoinbaseSmartWalletFactory);
 
         vm.prank(owner);
         account.addOwnerAddress(address(spendPermissionManager));
     }
 
     function test_approve() public {
-        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermission();
+        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermissionDebug();
 
         vm.prank(address(account));
         spendPermissionManager.approve(spendPermission);
@@ -30,7 +28,7 @@ contract DebugTest is Test, Base {
 
     function test_withdraw(address recipient) public {
         assumePayable(recipient);
-        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermission();
+        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermissionDebug();
 
         vm.prank(address(account));
         spendPermissionManager.approve(spendPermission);
@@ -40,7 +38,7 @@ contract DebugTest is Test, Base {
         spendPermissionManager.spend(spendPermission, recipient, 1 ether / 2);
     }
 
-    function _createSpendPermission() internal view returns (SpendPermissionManager.SpendPermission memory) {
+    function _createSpendPermissionDebug() internal view returns (SpendPermissionManager.SpendPermission memory) {
         return SpendPermissionManager.SpendPermission({
             account: address(account),
             spender: owner,

--- a/test/src/SpendPermissions/getHash.t.sol
+++ b/test/src/SpendPermissions/getHash.t.sol
@@ -80,8 +80,10 @@ contract GetHashTest is SpendPermissionManagerBase {
             period: period,
             allowance: allowance
         });
-        MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager();
-        MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager();
+        MockSpendPermissionManager mockSpendPermissionManager1 =
+            new MockSpendPermissionManager(mockCoinbaseSmartWalletFactory);
+        MockSpendPermissionManager mockSpendPermissionManager2 =
+            new MockSpendPermissionManager(mockCoinbaseSmartWalletFactory);
         bytes32 hash1 = mockSpendPermissionManager1.getHash(spendPermission);
         bytes32 hash2 = mockSpendPermissionManager2.getHash(spendPermission);
         assertNotEq(hash1, hash2);

--- a/test/src/SpendPermissions/validateSignature.t.sol
+++ b/test/src/SpendPermissions/validateSignature.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
+
+import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
+
+contract ValidateSignatureTest is SpendPermissionManagerBase {
+    function setUp() public {
+        _initializeSpendPermissionManager();
+        vm.prank(owner);
+        account.addOwnerAddress(address(mockSpendPermissionManager));
+    }
+
+    function test_validateSignature_revert_invalidSignature_ERC1271(
+        uint128 invalidPk,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(invalidPk != 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+
+        bytes memory invalidSignature = _signSpendPermission(spendPermission, invalidPk, 0);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSignature.selector));
+        mockSpendPermissionManager.validateSignature(spendPermission, invalidSignature);
+    }
+
+    function test_validateSignature_revert_invalidFactory(
+        uint128 invalidPk,
+        address invalidFactory,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(invalidFactory != address(mockCoinbaseSmartWalletFactory));
+
+        address ownerAddress = vm.addr(ownerPk);
+        bytes[] memory owners = new bytes[](1);
+        owners[0] = abi.encode(ownerAddress);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+
+        bytes memory signature = _signSpendPermission6492(spendPermission, invalidFactory, ownerPk, 0, owners);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.InvalidFactory.selector, invalidFactory, address(mockCoinbaseSmartWalletFactory)
+            )
+        );
+        mockSpendPermissionManager.validateSignature(spendPermission, signature);
+    }
+
+    function test_validateSignature_revert_deploymentFailedWithWrongDeployedAddress(
+        uint128 undeployedOwnerPk,
+        address arbitrarySecondOwner,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(undeployedOwnerPk != 0);
+        vm.assume(undeployedOwnerPk != ownerPk);
+        vm.assume(arbitrarySecondOwner != address(0));
+
+        address undeployedOwnerAddress = vm.addr(undeployedOwnerPk);
+        bytes[] memory owners = new bytes[](1);
+        owners[0] = abi.encode(undeployedOwnerAddress);
+        address counterfactualAccount = mockCoinbaseSmartWalletFactory.getAddress(owners, 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: counterfactualAccount,
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+
+        bytes[] memory tooManyOwners = new bytes[](2);
+        tooManyOwners[0] = abi.encode(undeployedOwnerAddress);
+        tooManyOwners[1] = abi.encode(arbitrarySecondOwner);
+
+        // creating an ERC6492 signature with init data that will lead to a different account address
+        bytes memory signature = _signSpendPermission6492(
+            spendPermission, address(mockCoinbaseSmartWalletFactory), ownerPk, 0, tooManyOwners
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.ERC6492DeployFailed.selector, "Deployed account does not match expected account"
+            )
+        );
+        mockSpendPermissionManager.validateSignature(spendPermission, signature);
+    }
+
+    function test_validateSignature_success_erc6492SignaturePreDeploy(
+        uint128 ownerPk,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(start > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(ownerPk != 0);
+        // generate the counterfactual address for the account
+        address ownerAddress = vm.addr(ownerPk);
+        bytes[] memory owners = new bytes[](1);
+        owners[0] = abi.encode(ownerAddress);
+        address counterfactualAccount = mockCoinbaseSmartWalletFactory.getAddress(owners, 0);
+
+        // create a 6492-compliant signature for the spend permission
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: counterfactualAccount,
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+        bytes memory signature = _signSpendPermission6492(spendPermission, ownerPk, 0, owners);
+        // verify that the account is not yet deployed
+        vm.assertEq(counterfactualAccount.code.length, 0);
+
+        // submit the spend permission with the signature, see permit succeed
+        mockSpendPermissionManager.validateSignature(spendPermission, signature);
+
+        // verify that the account is now deployed (has code) and that a call to isValidSignature returns true
+        vm.assertGt(counterfactualAccount.code.length, 0);
+    }
+
+    function test_approveWithSignature_success_erc6492SignatureAlreadyDeployed(
+        uint128 ownerPk,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(start > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(ownerPk != 0);
+        // generate the counterfactual address for the account
+        address ownerAddress = vm.addr(ownerPk);
+        bytes[] memory owners = new bytes[](1);
+        owners[0] = abi.encode(ownerAddress);
+        address counterfactualAccount = mockCoinbaseSmartWalletFactory.getAddress(owners, 0);
+        // deploy the account already
+        mockCoinbaseSmartWalletFactory.createAccount(owners, 0);
+        // create a 6492-compliant signature for the spend permission
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: counterfactualAccount,
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance
+        });
+        bytes memory signature = _signSpendPermission6492(spendPermission, ownerPk, 0, owners);
+        // verify that the account is already deployed
+        vm.assertGt(counterfactualAccount.code.length, 0);
+        mockSpendPermissionManager.validateSignature(spendPermission, signature);
+    }
+}


### PR DESCRIPTION
Decision: abandon our attempt to use ERC-6492 in the `SpendPermissionManager`.  Due to the highly privileged nature of the `SpendPermissionManager` as an owner of the user's smart account, the only safe way to implement deployment of pre-deploy smart accounts via the manager contract is to implement a severely restricted version of ERC6492 that dictates the exact factory and method that can be called for account deployment.  Because this is a stark deviation from the specified behavior of the 6492 protocol, we think it is a better design to avoid writing confusing partial implementations of this spec and instead place the burden of deploying pre-deploy accounts in a different location of the system, such as on the spenders/apps that want to use spend permissions. A variety of other restrictions (such as requiring the recipient of a spend to be the spender themselves) are lending weight to the idea that designing a "spender" smart account may be something of value we can offer the community, and the correct place to manage assurance of account deployment when necessary as well as fund and key management features.

[Linear ticket](https://linear.app/coinbase/issue/BW-428/draft-custom-factory-only-6492-implementation)

An attempt to support ERC-6492 pre-deploy signatures in the `SpendPermissionManager` by severely restricting the calls that can be executed from the arbitrary call data provided in the 6492 wrapper to only support one specific function on a specific factory and completely avoid the `prepareTo` path of the ERC spec.