### PR TITLE
Add a `salt` to the `SpendPermission` struct

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -30,6 +30,8 @@ contract SpendPermissionManager is EIP712 {
         uint48 start;
         /// @dev Timestamp this spend permission is valid until (unix seconds).
         uint48 end;
+        /// @dev An arbitrary salt to differentiate unique spend permissions with otherwise identical data.
+        uint256 salt;
     }
 
     /// @notice Spend Permission usage for a certain period.
@@ -43,7 +45,7 @@ contract SpendPermissionManager is EIP712 {
     }
 
     bytes32 constant MESSAGE_TYPEHASH = keccak256(
-        "SpendPermission(address account,address spender,address token,uint160 allowance,uint48 period,uint48 start,uint48 end)"
+        "SpendPermission(address account,address spender,address token,uint160 allowance,uint48 period,uint48 start,uint48 end,uint256 salt)"
     );
 
     /// @notice ERC-7528 address convention for native token (https://eips.ethereum.org/EIPS/eip-7528).

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -26,7 +26,8 @@ contract SpendPermissionManagerBase is Base {
             start: uint48(vm.getBlockTimestamp()),
             end: type(uint48).max,
             period: 604800,
-            allowance: 1 ether
+            allowance: 1 ether,
+            salt: 0
         });
     }
 

--- a/test/src/SpendPermissions/Debug.t.sol
+++ b/test/src/SpendPermissions/Debug.t.sol
@@ -48,7 +48,8 @@ contract DebugTest is Test, Base {
             start: 0,
             end: 1758791693, // 1 year from now
             period: 86400, // 1 day
-            allowance: 1 ether
+            allowance: 1 ether,
+            salt: 0
         });
     }
 }

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -17,7 +17,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(sender != address(0));
         vm.assume(sender != account);
@@ -29,7 +30,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(sender);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSender.selector, sender, account));
@@ -43,7 +45,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start >= end);
 
@@ -54,7 +57,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidStartEnd.selector, start, end));
@@ -67,7 +71,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         address spender,
         uint48 start,
         uint48 end,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
 
@@ -78,7 +83,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: 0,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroPeriod.selector));
@@ -91,7 +97,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         address spender,
         uint48 start,
         uint48 end,
-        uint48 period
+        uint48 period,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -103,7 +110,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: 0
+            allowance: 0,
+            salt: salt
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroAllowance.selector));
@@ -117,7 +125,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -130,7 +139,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -143,7 +153,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -156,7 +167,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
         vm.expectEmit(address(mockSpendPermissionManager));

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -19,7 +19,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(invalidPk != 0);
 
@@ -30,7 +31,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         bytes memory invalidSignature = _signSpendPermission(spendPermission, invalidPk, 0);
@@ -43,7 +45,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start >= end);
 
@@ -54,7 +57,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -62,9 +66,13 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
     }
 
-    function test_approveWithSignature_revert_zeroPeriod(address spender, uint48 start, uint48 end, uint160 allowance)
-        public
-    {
+    function test_approveWithSignature_revert_zeroPeriod(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint160 allowance,
+        uint256 salt
+    ) public {
         vm.assume(start < end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -74,7 +82,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: 0,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -82,9 +91,13 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
     }
 
-    function test_approveWithSignature_revert_zeroAllowance(address spender, uint48 start, uint48 end, uint48 period)
-        public
-    {
+    function test_approveWithSignature_revert_zeroAllowance(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint256 salt
+    ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
 
@@ -95,7 +108,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: 0
+            allowance: 0,
+            salt: salt
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -109,7 +123,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -122,7 +137,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -136,7 +152,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -149,7 +166,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);

--- a/test/src/SpendPermissions/getCurrentPeriod.t.sol
+++ b/test/src/SpendPermissions/getCurrentPeriod.t.sol
@@ -49,7 +49,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -64,7 +65,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.warp(start);
         SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
@@ -80,7 +82,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -97,7 +100,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(address(account));
@@ -117,7 +121,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -135,7 +140,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(address(account));
@@ -157,6 +163,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -175,7 +182,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(address(account));
@@ -196,7 +204,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(end > 0 && end < type(uint48).max);
         vm.assume(period > 0);
@@ -211,7 +220,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.warp(start);
@@ -225,7 +235,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         address permissionSigner,
         uint48 start,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         uint48 end = type(uint48).max;
         vm.assume(period > 0);
@@ -240,7 +251,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.warp(start);

--- a/test/src/SpendPermissions/getHash.t.sol
+++ b/test/src/SpendPermissions/getHash.t.sol
@@ -18,7 +18,8 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public view {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -27,7 +28,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         mockSpendPermissionManager.getHash(spendPermission);
     }
@@ -40,6 +42,7 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint64 chainId1,
         uint64 chainId2
     ) public {
@@ -53,7 +56,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.chainId(chainId1);
         bytes32 hash1 = mockSpendPermissionManager.getHash(spendPermission);
@@ -69,7 +73,8 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -78,7 +83,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager();
         MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager();

--- a/test/src/SpendPermissions/isApproved.t.sol
+++ b/test/src/SpendPermissions/isApproved.t.sol
@@ -17,7 +17,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -30,7 +31,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);
@@ -45,7 +47,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public view {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -54,7 +57,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.assertFalse(mockSpendPermissionManager.isApproved(spendPermission));
     }
@@ -66,7 +70,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -79,7 +84,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
 

--- a/test/src/SpendPermissions/revoke.t.sol
+++ b/test/src/SpendPermissions/revoke.t.sol
@@ -18,7 +18,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -33,7 +34,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);
@@ -52,7 +54,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -65,7 +68,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -81,7 +85,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -94,7 +99,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.startPrank(account);
         mockSpendPermissionManager.approve(spendPermission);

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -24,6 +24,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -40,7 +41,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -56,7 +58,8 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(invalidPk != 0);
         vm.assume(start > 0);
@@ -73,7 +76,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.warp(start);
@@ -90,6 +94,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(invalidPk != 0);
@@ -107,7 +112,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.warp(start);
@@ -123,6 +129,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -141,7 +148,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.deal(address(account), allowance);
         assertEq(address(account).balance, allowance);
@@ -169,6 +177,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -187,7 +196,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.deal(address(account), allowance);
         vm.deal(spender, 0);
@@ -213,6 +223,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -230,7 +241,8 @@ contract SpendTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         mockERC20.mint(address(account), allowance);
         vm.prank(address(account));

--- a/test/src/SpendPermissions/spendWithSignature.t.sol
+++ b/test/src/SpendPermissions/spendWithSignature.t.sol
@@ -23,6 +23,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -39,7 +40,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
         vm.startPrank(sender);
@@ -55,6 +57,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(invalidPk != 0);
@@ -72,7 +75,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         bytes memory invalidSignature = _signSpendPermission(spendPermission, invalidPk, 0);
         vm.warp(start);
@@ -88,6 +92,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -106,7 +111,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.deal(address(account), allowance);
         assertEq(address(account).balance, allowance);
@@ -133,6 +139,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -151,7 +158,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.deal(address(account), allowance);
         vm.prank(address(account));
@@ -177,6 +185,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -194,7 +203,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
         mockERC20.mint(address(account), allowance);

--- a/test/src/SpendPermissions/useSpendPermission.t.sol
+++ b/test/src/SpendPermissions/useSpendPermission.t.sol
@@ -17,7 +17,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -33,7 +34,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.expectRevert(SpendPermissionManager.UnauthorizedSpendPermission.selector);
@@ -46,7 +48,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -63,7 +66,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -80,7 +84,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -96,7 +101,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -115,6 +121,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint160 firstSpend,
         uint160 secondSpend
     ) public {
@@ -135,7 +142,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -169,7 +177,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -186,7 +195,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);
@@ -213,7 +223,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint160 spend
+        uint160 spend,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -230,7 +241,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);
@@ -249,7 +261,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint160 allowance
+        uint160 allowance,
+        uint256 salt
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -264,7 +277,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);
@@ -284,6 +298,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
+        uint256 salt,
         uint8 numberOfSpends
     ) public {
         vm.assume(start > 0);
@@ -302,7 +317,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             start: start,
             end: end,
             period: period,
-            allowance: allowance
+            allowance: allowance,
+            salt: salt
         });
 
         vm.prank(account);


### PR DESCRIPTION
It is possible for two different `SpendPermissions` to have earnestly identical data.  For example, an app might want to use spend permissions as one-time allowances, and use reasonable default values for start/end/period such as 0/max/max.  If the allowance for these one-offs are the same value, such as 1 ETH, the resultant `SpendPermission` structs would have the same hash despite being conceptually different entities, and that would mean the spendpermissions would be treated as the same single spend permission (including the fact that once revoked, a spendpermission -- by hash -- can never be unrevoked)

Apps would have to understand the importance of uniqueness in `SpendPermission` structs and use a different source of entropy (likely the `start` time) to differentiate their various permissions. We believe adding a `salt` to each`SpendPermission` struct not only makes the importance of uniqueness more obvious to developers, but also provides an avenue for the inclusion of arbitrary data in a `SpendPermission` that may be useful for apps to insert their own unique identifiers for any number of purposes.