### PR TITLE
Add `extraData` field to `SpendPermission` struct

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -32,6 +32,8 @@ contract SpendPermissionManager is EIP712 {
         uint48 end;
         /// @dev An arbitrary salt to differentiate unique spend permissions with otherwise identical data.
         uint256 salt;
+        /// @dev Arbitrary data to include in the signature.
+        bytes extraData;
     }
 
     /// @notice Spend Permission usage for a certain period.
@@ -45,7 +47,7 @@ contract SpendPermissionManager is EIP712 {
     }
 
     bytes32 constant MESSAGE_TYPEHASH = keccak256(
-        "SpendPermission(address account,address spender,address token,uint160 allowance,uint48 period,uint48 start,uint48 end,uint256 salt)"
+        "SpendPermission(address account,address spender,address token,uint160 allowance,uint48 period,uint48 start,uint48 end,uint256 salt,bytes extraData)"
     );
 
     /// @notice ERC-7528 address convention for native token (https://eips.ethereum.org/EIPS/eip-7528).

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -27,7 +27,8 @@ contract SpendPermissionManagerBase is Base {
             end: type(uint48).max,
             period: 604800,
             allowance: 1 ether,
-            salt: 0
+            salt: 0,
+            extraData: "0x"
         });
     }
 

--- a/test/src/SpendPermissions/Debug.t.sol
+++ b/test/src/SpendPermissions/Debug.t.sol
@@ -49,7 +49,8 @@ contract DebugTest is Test, Base {
             end: 1758791693, // 1 year from now
             period: 86400, // 1 day
             allowance: 1 ether,
-            salt: 0
+            salt: 0,
+            extraData: "0x"
         });
     }
 }

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+import {Test, console2} from "forge-std/Test.sol";
 
 contract ApproveTest is SpendPermissionManagerBase {
     function setUp() public {
@@ -18,11 +19,12 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(sender != address(0));
         vm.assume(sender != account);
-
+        console2.log(extraData.length);
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
             spender: spender,
@@ -31,7 +33,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(sender);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSender.selector, sender, account));
@@ -46,7 +49,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start >= end);
 
@@ -58,7 +62,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidStartEnd.selector, start, end));
@@ -72,7 +77,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
 
@@ -84,7 +90,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: 0,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroPeriod.selector));
@@ -98,7 +105,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -111,7 +119,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: 0,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroAllowance.selector));
@@ -126,7 +135,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -140,7 +150,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -154,7 +165,8 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -168,7 +180,8 @@ contract ApproveTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         vm.expectEmit(address(mockSpendPermissionManager));

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -20,7 +20,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(invalidPk != 0);
 
@@ -32,7 +33,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory invalidSignature = _signSpendPermission(spendPermission, invalidPk, 0);
@@ -46,7 +48,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start >= end);
 
@@ -58,7 +61,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -71,7 +75,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
 
@@ -83,7 +88,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: 0,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -96,7 +102,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 end,
         uint48 period,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -109,7 +116,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: 0,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -124,7 +132,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -138,7 +147,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
@@ -153,7 +163,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -167,7 +178,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);

--- a/test/src/SpendPermissions/getCurrentPeriod.t.sol
+++ b/test/src/SpendPermissions/getCurrentPeriod.t.sol
@@ -50,7 +50,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -66,7 +67,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.warp(start);
         SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
@@ -83,7 +85,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -101,7 +104,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(address(account));
@@ -122,7 +126,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -141,7 +146,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(address(account));
@@ -164,6 +170,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -183,7 +190,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(address(account));
@@ -205,7 +213,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(end > 0 && end < type(uint48).max);
         vm.assume(period > 0);
@@ -221,7 +230,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.warp(start);
@@ -236,7 +246,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint48 start,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         uint48 end = type(uint48).max;
         vm.assume(period > 0);
@@ -252,7 +263,8 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.warp(start);

--- a/test/src/SpendPermissions/getHash.t.sol
+++ b/test/src/SpendPermissions/getHash.t.sol
@@ -19,7 +19,8 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public view {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -29,7 +30,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         mockSpendPermissionManager.getHash(spendPermission);
     }
@@ -43,6 +45,7 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint64 chainId1,
         uint64 chainId2
     ) public {
@@ -57,7 +60,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.chainId(chainId1);
         bytes32 hash1 = mockSpendPermissionManager.getHash(spendPermission);
@@ -74,7 +78,8 @@ contract GetHashTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -84,7 +89,8 @@ contract GetHashTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager();
         MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager();

--- a/test/src/SpendPermissions/isApproved.t.sol
+++ b/test/src/SpendPermissions/isApproved.t.sol
@@ -18,7 +18,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -32,7 +33,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);
@@ -48,7 +50,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public view {
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
@@ -58,7 +61,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.assertFalse(mockSpendPermissionManager.isApproved(spendPermission));
     }
@@ -71,7 +75,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -85,7 +90,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
 

--- a/test/src/SpendPermissions/revoke.t.sol
+++ b/test/src/SpendPermissions/revoke.t.sol
@@ -19,7 +19,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -35,7 +36,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);
@@ -55,7 +57,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -69,7 +72,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -86,7 +90,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start < end);
         vm.assume(period > 0);
@@ -100,7 +105,8 @@ contract RevokeTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.startPrank(account);
         mockSpendPermissionManager.approve(spendPermission);

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -25,6 +25,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -42,7 +43,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -59,7 +61,8 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(invalidPk != 0);
         vm.assume(start > 0);
@@ -77,7 +80,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.warp(start);
@@ -95,6 +99,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(invalidPk != 0);
@@ -113,7 +118,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.warp(start);
@@ -130,6 +136,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -149,7 +156,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.deal(address(account), allowance);
         assertEq(address(account).balance, allowance);
@@ -178,6 +186,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -197,7 +206,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.deal(address(account), allowance);
         vm.deal(spender, 0);
@@ -224,6 +234,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -242,7 +253,8 @@ contract SpendTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         mockERC20.mint(address(account), allowance);
         vm.prank(address(account));

--- a/test/src/SpendPermissions/spendWithSignature.t.sol
+++ b/test/src/SpendPermissions/spendWithSignature.t.sol
@@ -24,6 +24,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(start > 0);
@@ -41,7 +42,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
         vm.startPrank(sender);
@@ -58,6 +60,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(invalidPk != 0);
@@ -76,7 +79,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         bytes memory invalidSignature = _signSpendPermission(spendPermission, invalidPk, 0);
         vm.warp(start);
@@ -93,6 +97,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -112,7 +117,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.deal(address(account), allowance);
         assertEq(address(account).balance, allowance);
@@ -140,6 +146,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -159,7 +166,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.deal(address(account), allowance);
         vm.prank(address(account));
@@ -186,6 +194,7 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 spend
     ) public {
         vm.assume(spender != address(account)); // otherwise balance checks can fail
@@ -204,7 +213,8 @@ contract SpendWithSignatureTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
         mockERC20.mint(address(account), allowance);

--- a/test/src/SpendPermissions/useSpendPermission.t.sol
+++ b/test/src/SpendPermissions/useSpendPermission.t.sol
@@ -18,7 +18,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -35,7 +36,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.expectRevert(SpendPermissionManager.UnauthorizedSpendPermission.selector);
@@ -49,7 +51,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -67,7 +70,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -85,7 +89,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -102,7 +107,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -122,6 +128,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint160 firstSpend,
         uint160 secondSpend
     ) public {
@@ -143,7 +150,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
         vm.prank(account);
         mockSpendPermissionManager.approve(spendPermission);
@@ -178,7 +186,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -196,7 +205,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);
@@ -224,7 +234,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint160 spend,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -242,7 +253,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);
@@ -262,7 +274,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 end,
         uint48 period,
         uint160 allowance,
-        uint256 salt
+        uint256 salt,
+        bytes memory extraData
     ) public {
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -278,7 +291,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);
@@ -299,6 +313,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint48 period,
         uint160 allowance,
         uint256 salt,
+        bytes memory extraData,
         uint8 numberOfSpends
     ) public {
         vm.assume(start > 0);
@@ -318,7 +333,8 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             end: end,
             period: period,
             allowance: allowance,
-            salt: salt
+            salt: salt,
+            extraData: extraData
         });
 
         vm.prank(account);


### PR DESCRIPTION
A `SpendPermission` struct now has two fields for arbitrary data. The `uint256 salt` is intended as an explicit field for providing entropy to `SpendPermission` structs (which are managed and identified by their hash, implications described [here](https://github.com/coinbase/spend-permissions/pull/11)).  This new field, `bytes extraData` is intended as a location for associating (and signing) arbitrary data with a spend permission that can be used by the spender logic for any number of individual use cases. For example, we discussed the case of basename renewal. An account may own a variety of different basenames.  The data encoded in `extraData` in a spendpermission could authorize an auto-renewal of one of their basenames, encoded in the `extraData` and honored by the spender implementation, which could be designed to enforce that guarantee that only the basename intended by the user will be renewed.