### PR TITLE
Add validation for empty batches, zero address spender, zero address token

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -282,8 +282,16 @@ contract SpendPermissionManager is EIP712 {
         if (permissionDetailsLen == 0) revert EmptyBatch();
         bytes32[] memory permissionDetailsHashes = new bytes32[](permissionDetailsLen);
         for (uint256 i; i < permissionDetailsLen; i++) {
-            permissionDetailsHashes[i] =
-                keccak256(abi.encode(TOKEN_ALLOWANCE_TYPEHASH, spendPermissionBatch.permissions[i]));
+            permissionDetailsHashes[i] = keccak256(
+                abi.encode(
+                    TOKEN_ALLOWANCE_TYPEHASH,
+                    spendPermissionBatch.permissions[i].spender,
+                    spendPermissionBatch.permissions[i].token,
+                    spendPermissionBatch.permissions[i].allowance,
+                    spendPermissionBatch.permissions[i].salt,
+                    keccak256(spendPermissionBatch.permissions[i].extraData)
+                )
+            );
         }
 
         return _hashTypedData(
@@ -361,9 +369,12 @@ contract SpendPermissionManager is EIP712 {
     ///
     /// @param spendPermission Details of the spend permission.
     function _approve(SpendPermission memory spendPermission) internal {
+        // check token is not the zero adddress
         if (spendPermission.token == address(0)) {
             revert InvalidTokenZeroAddress();
         }
+
+        // check spender is not the zero address
         if (spendPermission.spender == address(0)) {
             revert InvalidSpenderZeroAddress();
         }

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -103,11 +103,8 @@ contract SpendPermissionManager is EIP712 {
     /// @notice Invalid signature.
     error InvalidSignature();
 
-    /// @notice Spend permission already exists.
-    error ExistingSpendPermission(bytes32 hash);
-
     /// @notice Empty batch of spend permissions.
-    error EmptyBatch(bytes32 hash);
+    error EmptyBatch();
 
     /// @notice Spend Permission start time is not strictly less than end time.
     ///
@@ -243,7 +240,6 @@ contract SpendPermissionManager is EIP712 {
         }
         // loop through each unique spend permission in the batch and approve it
         uint256 batchLen = spendPermissionBatch.permissions.length;
-        if (batchLen == 0) revert EmptyBatch(batchHash);
         for (uint256 i; i < batchLen; i++) {
             _approve(
                 SpendPermission({
@@ -277,6 +273,7 @@ contract SpendPermissionManager is EIP712 {
     /// @return hash Hash of the spend permission batch.
     function getBatchHash(SpendPermissionBatch memory spendPermissionBatch) public view returns (bytes32) {
         uint256 permissionDetailsLen = spendPermissionBatch.permissions.length;
+        if (permissionDetailsLen == 0) revert EmptyBatch();
         bytes32[] memory permissionDetailsHashes = new bytes32[](permissionDetailsLen);
         for (uint256 i; i < permissionDetailsLen; i++) {
             permissionDetailsHashes[i] =
@@ -358,9 +355,6 @@ contract SpendPermissionManager is EIP712 {
     ///
     /// @param spendPermission Details of the spend permission.
     function _approve(SpendPermission memory spendPermission) internal {
-        // revert if spend permission has already been approved (regardless of revoke status)
-        if (isApproved(spendPermission)) revert ExistingSpendPermission(getHash(spendPermission));
-
         // check start is strictly before end
         if (spendPermission.start >= spendPermission.end) {
             revert InvalidStartEnd(spendPermission.start, spendPermission.end);

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -100,6 +100,12 @@ contract SpendPermissionManager is EIP712 {
     /// @param sender Expected sender to be valid.
     error InvalidSender(address sender, address expected);
 
+    /// @notice Invalid zero address for token.
+    error InvalidTokenZeroAddress();
+
+    /// @notice Invalid zero address for spender.
+    error InvalidSpenderZeroAddress();
+
     /// @notice Invalid signature.
     error InvalidSignature();
 
@@ -355,6 +361,13 @@ contract SpendPermissionManager is EIP712 {
     ///
     /// @param spendPermission Details of the spend permission.
     function _approve(SpendPermission memory spendPermission) internal {
+        if (spendPermission.token == address(0)) {
+            revert InvalidTokenZeroAddress();
+        }
+        if (spendPermission.spender == address(0)) {
+            revert InvalidSpenderZeroAddress();
+        }
+
         // check start is strictly before end
         if (spendPermission.start >= spendPermission.end) {
             revert InvalidStartEnd(spendPermission.start, spendPermission.end);

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -251,11 +251,11 @@ contract SpendPermissionManager is EIP712 {
                 SpendPermission({
                     account: spendPermissionBatch.account,
                     spender: spendPermissionBatch.permissions[i].spender,
-                    start: spendPermissionBatch.start,
-                    end: spendPermissionBatch.end,
-                    period: spendPermissionBatch.period,
                     token: spendPermissionBatch.permissions[i].token,
                     allowance: spendPermissionBatch.permissions[i].allowance,
+                    period: spendPermissionBatch.period,
+                    start: spendPermissionBatch.start,
+                    end: spendPermissionBatch.end,
                     salt: spendPermissionBatch.permissions[i].salt,
                     extraData: spendPermissionBatch.permissions[i].extraData
                 })

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -126,45 +126,6 @@ contract ApproveTest is SpendPermissionManagerBase {
         vm.stopPrank();
     }
 
-    function test_approve_revert_existingSpendPermission(
-        address account,
-        address spender,
-        uint48 start,
-        uint48 end,
-        uint48 period,
-        uint160 allowance,
-        uint256 salt,
-        bytes memory extraData
-    ) public {
-        vm.assume(start < end);
-        vm.assume(period > 0);
-        vm.assume(allowance > 0);
-
-        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
-            account: account,
-            spender: spender,
-            token: NATIVE_TOKEN,
-            start: start,
-            end: end,
-            period: period,
-            allowance: allowance,
-            salt: salt,
-            extraData: extraData
-        });
-        vm.startPrank(account);
-        // first approval succeeds
-        mockSpendPermissionManager.approve(spendPermission);
-        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
-        // attempt to approve again fails
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                SpendPermissionManager.ExistingSpendPermission.selector,
-                mockSpendPermissionManager.getHash(spendPermission)
-            )
-        );
-        mockSpendPermissionManager.approve(spendPermission);
-    }
-
     function test_approve_success_isAuthorized(
         address account,
         address spender,

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -126,6 +126,45 @@ contract ApproveTest is SpendPermissionManagerBase {
         vm.stopPrank();
     }
 
+    function test_approve_revert_existingSpendPermission(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        // first approval succeeds
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+        // attempt to approve again fails
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.ExistingSpendPermission.selector,
+                mockSpendPermissionManager.getHash(spendPermission)
+            )
+        );
+        mockSpendPermissionManager.approve(spendPermission);
+    }
+
     function test_approve_success_isAuthorized(
         address account,
         address spender,

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -50,6 +50,7 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start >= end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -69,6 +70,67 @@ contract ApproveTest is SpendPermissionManagerBase {
         vm.stopPrank();
     }
 
+    function test_approve_revert_invalidTokenZeroAddress(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: spender,
+            token: address(0),
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidTokenZeroAddress.selector));
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approve_revert_invalidSpenderZeroAddress(
+        address account,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(token != address(0));
+        vm.assume(start < end);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: address(0),
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSpenderZeroAddress.selector));
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.stopPrank();
+    }
+
     function test_approve_revert_zeroPeriod(
         address account,
         address spender,
@@ -78,6 +140,7 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -106,6 +169,7 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
 
@@ -136,6 +200,7 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -166,6 +231,7 @@ contract ApproveTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);

--- a/test/src/SpendPermissions/approveBatchWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveBatchWithSignature.t.sol
@@ -121,60 +121,10 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
             permissions: permissions
         });
 
-        bytes memory signature = _signSpendPermissionBatch(spendPermissionBatch, ownerPk, 0);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                SpendPermissionManager.EmptyBatch.selector,
-                mockSpendPermissionManager.getBatchHash(spendPermissionBatch)
-            )
-        );
-        mockSpendPermissionManager.approveBatchWithSignature(spendPermissionBatch, signature);
-    }
-
-    function test_approveBatchWithSignature_revert_duplicateSpendPermissionInBatch(
-        address spender,
-        address token,
-        uint48 start,
-        uint48 end,
-        uint48 period,
-        uint160 allowance,
-        uint256 salt,
-        bytes memory extraData
-    ) public {
-        vm.assume(start < end);
-        vm.assume(period > 0);
-        vm.assume(allowance > 0);
-        SpendPermissionManager.PermissionDetails memory permissionDetails = SpendPermissionManager.PermissionDetails({
-            token: token,
-            allowance: allowance,
-            spender: spender,
-            salt: salt,
-            extraData: extraData
-        });
-        SpendPermissionManager.PermissionDetails memory duplicatePermissionDetails = SpendPermissionManager
-            .PermissionDetails({token: token, allowance: allowance, spender: spender, salt: salt, extraData: extraData});
-        SpendPermissionManager.PermissionDetails[] memory permissions =
-            new SpendPermissionManager.PermissionDetails[](2);
-        permissions[0] = permissionDetails;
-        permissions[1] = duplicatePermissionDetails;
-        SpendPermissionManager.SpendPermissionBatch memory spendPermissionBatch = SpendPermissionManager
-            .SpendPermissionBatch({
-            account: address(account),
-            start: start,
-            end: end,
-            period: period,
-            permissions: permissions
-        });
-        SpendPermissionManager.SpendPermission[] memory expectedSpendPermissions =
-            _generateSpendPermissionArrayFromBatch(spendPermissionBatch);
-        bytes memory signature = _signSpendPermissionBatch(spendPermissionBatch, ownerPk, 0);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                SpendPermissionManager.ExistingSpendPermission.selector,
-                mockSpendPermissionManager.getHash(expectedSpendPermissions[1])
-            )
-        );
-        mockSpendPermissionManager.approveBatchWithSignature(spendPermissionBatch, signature);
+        bytes memory stubSignature = abi.encodePacked("0x"); // can't get a valid signature for an empty batch because
+            // getBatchHash reverts
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptyBatch.selector));
+        mockSpendPermissionManager.approveBatchWithSignature(spendPermissionBatch, stubSignature);
     }
 
     function test_approveBatchWithSignature_success_isApproved(

--- a/test/src/SpendPermissions/approveBatchWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveBatchWithSignature.t.sol
@@ -23,6 +23,8 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt1,
         uint256 salt2
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -70,6 +72,8 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
         uint160 allowance1,
         uint256 salt
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance1 > 0);
@@ -138,6 +142,8 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt1,
         uint256 salt2
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance1 > 0);
@@ -186,6 +192,8 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt1,
         uint256 salt2
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance1 > 0);

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -125,6 +125,45 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
     }
 
+    function test_approveWithSignature_revert_existingSpendPermission(
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+
+        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
+        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.ExistingSpendPermission.selector,
+                mockSpendPermissionManager.getHash(spendPermission)
+            )
+        );
+        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+    }
+
     function test_approveWithSignature_success_isApproved(
         address spender,
         address token,

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -125,45 +125,6 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
     }
 
-    function test_approveWithSignature_revert_existingSpendPermission(
-        address spender,
-        address token,
-        uint48 start,
-        uint48 end,
-        uint48 period,
-        uint160 allowance,
-        uint256 salt,
-        bytes memory extraData
-    ) public {
-        vm.assume(start < end);
-        vm.assume(period > 0);
-        vm.assume(allowance > 0);
-
-        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
-            account: address(account),
-            spender: spender,
-            token: token,
-            start: start,
-            end: end,
-            period: period,
-            allowance: allowance,
-            salt: salt,
-            extraData: extraData
-        });
-
-        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
-        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
-        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                SpendPermissionManager.ExistingSpendPermission.selector,
-                mockSpendPermissionManager.getHash(spendPermission)
-            )
-        );
-        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
-    }
-
     function test_approveWithSignature_success_isApproved(
         address spender,
         address token,

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -23,6 +23,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(invalidPk != 0);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -51,6 +53,7 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start >= end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -78,6 +81,7 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -105,6 +109,7 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
 
@@ -135,6 +140,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -166,6 +173,8 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);

--- a/test/src/SpendPermissions/getBatchHash.t.sol
+++ b/test/src/SpendPermissions/getBatchHash.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
+
+import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+import {MockSpendPermissionManager} from "../../mocks/MockSpendPermissionManager.sol";
+
+contract GetBatchHashTest is SpendPermissionManagerBase {
+    function setUp() public {
+        _initializeSpendPermissionManager();
+    }
+
+    function test_getBatchHash_reverts_emptyBatch(
+        address account,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance
+    ) public {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        SpendPermissionManager.PermissionDetails[] memory permissions =
+            new SpendPermissionManager.PermissionDetails[](0);
+        SpendPermissionManager.SpendPermissionBatch memory spendPermissionBatch = SpendPermissionManager
+            .SpendPermissionBatch({
+            account: address(account),
+            start: start,
+            end: end,
+            period: period,
+            permissions: permissions
+        });
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptyBatch.selector));
+        mockSpendPermissionManager.getBatchHash(spendPermissionBatch);
+    }
+
+    function test_getBatchHash_success(
+        address account,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint128 salt
+    ) public view {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        SpendPermissionManager.PermissionDetails memory permissionDetails1 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: uint256(salt),
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails memory permissionDetails2 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: uint256(salt) + 1,
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails[] memory permissions =
+            new SpendPermissionManager.PermissionDetails[](2);
+        permissions[0] = permissionDetails1;
+        permissions[1] = permissionDetails2;
+        SpendPermissionManager.SpendPermissionBatch memory spendPermissionBatch = SpendPermissionManager
+            .SpendPermissionBatch({
+            account: address(account),
+            start: start,
+            end: end,
+            period: period,
+            permissions: permissions
+        });
+        mockSpendPermissionManager.getBatchHash(spendPermissionBatch);
+    }
+
+    function test_getBatchHash_success_uniqueHashPerChain(
+        address account,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint128 salt,
+        uint64 chainId1,
+        uint64 chainId2
+    ) public {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(chainId1 != chainId2);
+        vm.assume(chainId1 > 0);
+        vm.assume(chainId2 > 0);
+        SpendPermissionManager.PermissionDetails memory permissionDetails1 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: uint256(salt),
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails memory permissionDetails2 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: uint256(salt) + 1,
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails[] memory permissions =
+            new SpendPermissionManager.PermissionDetails[](2);
+        permissions[0] = permissionDetails1;
+        permissions[1] = permissionDetails2;
+        SpendPermissionManager.SpendPermissionBatch memory spendPermissionBatch = SpendPermissionManager
+            .SpendPermissionBatch({
+            account: address(account),
+            start: start,
+            end: end,
+            period: period,
+            permissions: permissions
+        });
+        vm.chainId(chainId1);
+        bytes32 hash1 = mockSpendPermissionManager.getBatchHash(spendPermissionBatch);
+        vm.chainId(chainId2);
+        bytes32 hash2 = mockSpendPermissionManager.getBatchHash(spendPermissionBatch);
+        assertNotEq(hash1, hash2);
+    }
+
+    function test_getBatchHash_success_uniqueHashPerContract(
+        address account,
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt1,
+        uint256 salt2
+    ) public {
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        SpendPermissionManager.PermissionDetails memory permissionDetails1 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: salt1,
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails memory permissionDetails2 = SpendPermissionManager.PermissionDetails({
+            token: token,
+            allowance: allowance,
+            spender: spender,
+            salt: salt2,
+            extraData: "0x"
+        });
+        SpendPermissionManager.PermissionDetails[] memory permissions =
+            new SpendPermissionManager.PermissionDetails[](2);
+        permissions[0] = permissionDetails1;
+        permissions[1] = permissionDetails2;
+        SpendPermissionManager.SpendPermissionBatch memory spendPermissionBatch = SpendPermissionManager
+            .SpendPermissionBatch({
+            account: address(account),
+            start: start,
+            end: end,
+            period: period,
+            permissions: permissions
+        });
+        MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager();
+        MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager();
+        bytes32 hash1 = mockSpendPermissionManager1.getBatchHash(spendPermissionBatch);
+        bytes32 hash2 = mockSpendPermissionManager2.getBatchHash(spendPermissionBatch);
+        assertNotEq(hash1, hash2);
+    }
+}

--- a/test/src/SpendPermissions/isApproved.t.sol
+++ b/test/src/SpendPermissions/isApproved.t.sol
@@ -21,6 +21,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -53,6 +55,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public view {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
             spender: spender,
@@ -78,6 +82,8 @@ contract IsApprovedTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);

--- a/test/src/SpendPermissions/revoke.t.sol
+++ b/test/src/SpendPermissions/revoke.t.sol
@@ -22,6 +22,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -60,6 +62,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);
@@ -93,6 +97,8 @@ contract RevokeTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
         vm.assume(start < end);
         vm.assume(period > 0);
         vm.assume(allowance > 0);

--- a/test/src/SpendPermissions/useSpendPermission.t.sol
+++ b/test/src/SpendPermissions/useSpendPermission.t.sol
@@ -12,7 +12,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_revert_unauthorizedSpendPermission(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -21,6 +21,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(period > 0);
@@ -30,7 +31,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -46,7 +47,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_revert_spendValueOverflow(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -54,6 +55,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -64,7 +66,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
             // rejects too many inputs
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -83,7 +85,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_revert_exceededSpendPermission(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -92,6 +94,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -101,7 +104,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -122,7 +125,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_revert_exceededSpendPermission_accruedSpend(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -132,6 +135,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint160 firstSpend,
         uint160 secondSpend
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -144,7 +148,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -180,7 +184,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_success_emitsEvent(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -189,6 +193,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -199,7 +204,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -228,7 +233,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_success_setsState(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -237,6 +242,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -247,7 +253,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -269,7 +275,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_success_maxAllowance(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -277,6 +283,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -285,7 +292,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -307,7 +314,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
     function test_useSpendPermission_success_incrementalSpends(
         address account,
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -316,6 +323,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
         bytes memory extraData,
         uint8 numberOfSpends
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -327,7 +335,7 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,


### PR DESCRIPTION
Adds validation for:

- an empty batch of spend permissions
- zero address spender
- zero address token

also adds tests for `getBatchHash` and a few other misc cleanup items