### PR TITLE
Add non-zero spender enforcement in tests

### DIFF
--- a/test/base/Base.sol
+++ b/test/base/Base.sol
@@ -17,16 +17,16 @@ contract Base is Test {
     bytes4 constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
     uint256 ownerPk = uint256(keccak256("owner"));
     address owner = vm.addr(ownerPk);
-    uint256 permissionSignerPk = uint256(keccak256("permissionSigner"));
-    address permissionSigner = vm.addr(permissionSignerPk);
+    uint256 spenderPk = uint256(keccak256("spender"));
+    address spender = vm.addr(spenderPk);
     uint256 p256PrivateKey = uint256(0x03d99692017473e2d631945a812607b23269d85721e0f370b8d3e7d29a874fd2);
     bytes p256PublicKey =
         hex"1c05286fe694493eae33312f2d2e0d0abeda8db76238b7a204be1fb87f54ce4228fef61ef4ac300f631657635c28e59bfb2fe71bce1634c81c65642042f6dc4d";
-    MockContractSigner permissionSignerContract;
+    MockContractSigner spenderContract;
     MockCoinbaseSmartWallet account;
 
     function _initialize() internal {
-        permissionSignerContract = new MockContractSigner(permissionSigner);
+        spenderContract = new MockContractSigner(spender);
 
         account = new MockCoinbaseSmartWallet();
         bytes[] memory owners = new bytes[](1);

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -31,7 +31,7 @@ contract SpendPermissionManagerBase is Base {
     function _createSpendPermission() internal view returns (SpendPermissionManager.SpendPermission memory) {
         return SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: uint48(vm.getBlockTimestamp()),
             end: type(uint48).max,

--- a/test/src/SpendPermissions/getCurrentPeriod.t.sol
+++ b/test/src/SpendPermissions/getCurrentPeriod.t.sol
@@ -88,6 +88,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -129,6 +130,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         uint256 salt,
         bytes memory extraData
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -173,6 +175,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         bytes memory extraData,
         uint160 spend
     ) public {
+        vm.assume(spender != address(0));
         vm.assume(start > 0);
         vm.assume(end > 0);
         vm.assume(start < end);
@@ -181,7 +184,6 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         vm.assume(allowance > 0);
         vm.assume(spend > 0);
         vm.assume(spend <= allowance);
-        // vm.assume(spender )
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),

--- a/test/src/SpendPermissions/getCurrentPeriod.t.sol
+++ b/test/src/SpendPermissions/getCurrentPeriod.t.sol
@@ -45,7 +45,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_success_unusedAllowance(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -61,7 +61,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -79,7 +79,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_success_startOfPeriod(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -98,7 +98,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -120,7 +120,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_success_endOfPeriod(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -140,7 +140,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -164,7 +164,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_succes_resetsAfterPeriod(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -181,10 +181,11 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
         vm.assume(allowance > 0);
         vm.assume(spend > 0);
         vm.assume(spend <= allowance);
+        // vm.assume(spender )
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -208,7 +209,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_success_periodEndWithinPermissionEnd(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 end,
         uint48 period,
@@ -224,7 +225,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,
@@ -242,7 +243,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
     }
 
     function test_getCurrentPeriod_success_periodEndWithinPermissionEnd_maxValue(
-        address permissionSigner,
+        address spender,
         uint48 start,
         uint48 period,
         uint160 allowance,
@@ -257,7 +258,7 @@ contract GetCurrentPeriodTest is SpendPermissionManagerBase {
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: address(account),
-            spender: permissionSigner,
+            spender: spender,
             token: NATIVE_TOKEN,
             start: start,
             end: end,


### PR DESCRIPTION
Need to add automated foundry tests, but here's proof of it on local.
<img width="853" alt="Screenshot 2024-10-29 at 9 19 13 PM" src="https://github.com/user-attachments/assets/fbb1d1ea-6205-4973-b2df-e0e8bee41373">
