### PR TITLE
Add sample ffi tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Compiler files
 cache/
 out/
+node_modules/
 
 # Ignores development broadcast logs
 /broadcast

--- a/node/getBatchHash.js
+++ b/node/getBatchHash.js
@@ -1,0 +1,60 @@
+import { hashTypedData, zeroAddress } from "viem";
+
+function getHash(chainId, verifyingContract, spendPermissionBatch) {
+  return hashTypedData({
+    domain: {
+      name: "Spend Permission Manager",
+      version: "1",
+      chainId,
+      verifyingContract,
+    },
+    message: spendPermissionBatch,
+    types: {
+      SpendPermissionBatch: [
+        { name: "account", type: "address" },
+        { name: "period", type: "uint48" },
+        { name: "start", type: "uint48" },
+        { name: "end", type: "uint48" },
+        { name: "permissions", type: "PermissionDetails[]" },
+      ],
+      PermissionDetails: [
+        { name: "spender", type: "address" },
+        { name: "token", type: "address" },
+        { name: "allowance", type: "uint160" },
+        { name: "salt", type: "uint256" },
+        { name: "extraData", type: "bytes" },
+      ],
+    },
+    primaryType: "SpendPermissionBatch",
+  });
+}
+
+const args = process.argv.slice(2);
+
+// Check expected arguments
+if (args.length !== 11) {
+  console.log("Please provide exactly 11 arguments.");
+  process.exit(1);
+}
+
+const chainId = parseInt(args[0]);
+const verifyingContract = args[1];
+const spendPermissionBatch = {
+  account: args[2],
+  period: parseInt(args[6]),
+  start: parseInt(args[7]),
+  end: parseInt(args[8]),
+  permissions: [
+    {
+      spender: args[3],
+      token: args[4],
+      allowance: BigInt(args[5]),
+      salt: BigInt(args[9]),
+      extraData: args[10],
+    },
+  ],
+};
+
+// console.log({ chainId, verifyingContract, spendPermission });
+
+console.log(getHash(chainId, verifyingContract, spendPermissionBatch));

--- a/node/getHash.js
+++ b/node/getHash.js
@@ -1,0 +1,53 @@
+import { hashTypedData, zeroAddress } from "viem";
+
+function getHash(chainId, verifyingContract, spendPermission) {
+  return hashTypedData({
+    domain: {
+      name: "Spend Permission Manager",
+      version: "1",
+      chainId,
+      verifyingContract,
+    },
+    message: spendPermission,
+    types: {
+      SpendPermission: [
+        { name: "account", type: "address" },
+        { name: "spender", type: "address" },
+        { name: "token", type: "address" },
+        { name: "allowance", type: "uint160" },
+        { name: "period", type: "uint48" },
+        { name: "start", type: "uint48" },
+        { name: "end", type: "uint48" },
+        { name: "salt", type: "uint256" },
+        { name: "extraData", type: "bytes" },
+      ],
+    },
+    primaryType: "SpendPermission",
+  });
+}
+
+const args = process.argv.slice(2);
+
+// Check expected arguments
+if (args.length !== 11) {
+  console.log("Please provide exactly 11 arguments.");
+  process.exit(1);
+}
+
+const chainId = parseInt(args[0]);
+const verifyingContract = args[1];
+const spendPermission = {
+  account: args[2],
+  spender: args[3],
+  token: args[4],
+  allowance: BigInt(args[5]),
+  period: parseInt(args[6]),
+  start: parseInt(args[7]),
+  end: parseInt(args[8]),
+  salt: BigInt(args[9]),
+  extraData: args[10],
+};
+
+// console.log({ chainId, verifyingContract, spendPermission });
+
+console.log(getHash(chainId, verifyingContract, spendPermission));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,178 @@
+{
+  "name": "spend-permissions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spend-permissions",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "viem": "^2.21.37"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
+      "dependencies": {
+        "@noble/curves": "~1.6.0",
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.7"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "dependencies": {
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.21.37",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.37.tgz",
+      "integrity": "sha512-JupwyttT4aJNnP9+kD7E8jorMS5VmgpC3hm3rl5zXsO8WNBTsP3JJqZUSg4AG6s2lTrmmpzS/qpmXMZu5gJw5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.0",
+        "@noble/curves": "1.6.0",
+        "@noble/hashes": "1.5.0",
+        "@scure/bip32": "1.5.0",
+        "@scure/bip39": "1.4.0",
+        "abitype": "1.0.6",
+        "isows": "1.0.6",
+        "webauthn-p256": "0.0.10",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webauthn-p256": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
+      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "spend-permissions",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "> :information_source: These contracts are unaudited. Please use at your own risk.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "viem": "^2.21.37"
+  }
+}

--- a/test/src/SpendPermissions/getHash.t.sol
+++ b/test/src/SpendPermissions/getHash.t.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {console2} from "forge-std/console2.sol";
+import {LibString} from "solady/utils/LibString.sol";
+
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
@@ -97,5 +100,29 @@ contract GetHashTest is SpendPermissionManagerBase {
         bytes32 hash1 = mockSpendPermissionManager1.getHash(spendPermission);
         bytes32 hash2 = mockSpendPermissionManager2.getHash(spendPermission);
         assertNotEq(hash1, hash2);
+    }
+
+    function test_getHash_success_matchesViem(SpendPermissionManager.SpendPermission calldata spendPermission) public {
+        string[] memory inputs = new string[](13);
+        inputs[0] = "node";
+        inputs[1] = "node/getHash.js";
+        inputs[2] = LibString.toString(block.chainid);
+        inputs[3] = LibString.toHexString(address(mockSpendPermissionManager));
+        inputs[4] = LibString.toHexString(spendPermission.account);
+        inputs[5] = LibString.toHexString(spendPermission.spender);
+        inputs[6] = LibString.toHexString(spendPermission.token);
+        inputs[7] = LibString.toString(spendPermission.allowance);
+        inputs[8] = LibString.toString(spendPermission.period);
+        inputs[9] = LibString.toString(spendPermission.start);
+        inputs[10] = LibString.toString(spendPermission.end);
+        inputs[11] = LibString.toString(spendPermission.salt);
+        inputs[12] = LibString.toHexString(spendPermission.extraData);
+
+        bytes memory res = vm.ffi(inputs);
+        bytes32 viemHash = abi.decode(res, (bytes32));
+
+        bytes32 contractHash = mockSpendPermissionManager.getHash(spendPermission);
+
+        assertEq(viemHash, contractHash);
     }
 }


### PR DESCRIPTION
Not sure if I like this fully yet, but keeping here as draft for sample implementation and to start discussion. I'm most bothered by having to add `--ffi` flag to tests to trigger this which related to the other problem which is the security risk of using `ffi` to run arbitrary scripts on the devs machine.

Helped me catch the batch hash issue though, so maybe we could just keep this outside of `main` in a dedicated branch we can rebase to or just copy files from?

Run yourself by doing `npm i`, followed by `forge test` to see it yell at you, `forge test --ffi` to get it to work (notice the delay in speed)