### PR TITLE
Final pass of non-functional changes

### DIFF
--- a/src/PublicERC6492Validator.sol
+++ b/src/PublicERC6492Validator.sol
@@ -5,34 +5,37 @@ import {SignatureCheckerLib} from "solady/utils/SignatureCheckerLib.sol";
 
 /// @title PublicERC6492Validator
 ///
-/// @notice Validate ERC-6492 signatures and perform contract deployment or preparation when necessary.
+/// @notice Validate ERC-6492 signatures and perform contract deployment or preparation when necessary
+///         (https://eips.ethereum.org/EIPS/eip-6492).
 ///
-/// @dev Dedicated contract for validating ERC-6492 (and therefore also ERC-1271) signatures,
-/// performing contract deployment or preparation when necessary from an unprivileged context.
-/// (https://eips.ethereum.org/EIPS/eip-6492)
+/// @dev Anyone can make arbitrary calls from this contract, so it should never have priviledged access control.
 ///
 /// @author Coinbase (https://github.com/coinbase/spend-permissions)
 contract PublicERC6492Validator {
-    /// @dev Returns whether `signature` is valid for `hash`.
-    /// If the signature is postfixed with the ERC6492 magic number, it will attempt to
-    /// deploy / prepare the `signer` smart account before doing a regular ERC1271 check.
-    /// Note: This function is NOT reentrancy safe.
-    function isValidSignatureNowAllowSideEffects(address account, bytes32 hash, bytes memory signature)
+    /// @notice Validate contract signature and execute side effects if provided.
+    ///
+    /// @dev If the signature is postfixed with the ERC-6492 magic value, an external call to deploy/prepare the account
+    ///      is made before calling ERC-1271 `isValidSignature`.
+    /// @dev This function is NOT reentrancy safe.
+    ///
+    /// @return isValid True if signature is valid.
+    function isValidSignatureNowAllowSideEffects(address account, bytes32 hash, bytes calldata signature)
         public
         returns (bool)
     {
         return SignatureCheckerLib.isValidERC6492SignatureNowAllowSideEffects(account, hash, signature);
     }
 
-    /// @dev Returns whether `signature` is valid for `hash`.
-    /// If the signature is postfixed with the ERC6492 magic number, it will attempt
-    /// to use a reverting verifier to deploy / prepare the `signer` smart account
-    /// and do a `isValidSignature` check via the reverting verifier.
-    /// Note: This function is reentrancy safe.
-    /// The reverting verifier must be deployed.
-    /// Otherwise, the function will return false if `signer` is not yet deployed / prepared.
-    /// See: https://gist.github.com/Vectorized/846a474c855eee9e441506676800a9ad
-    function isValidSignatureNow(address account, bytes32 hash, bytes memory signature) public returns (bool) {
+    /// @notice Validate contract signature without side effects.
+    ///
+    /// @dev If the signature is postfixed with the ERC-6492 magic value, an external call to a reverting verifier to
+    ///      deploy/prepare the account is made before calling ERC-1271 `isValidSignature` via the reverting verifier.
+    ///      The reverting verifier must be deployed or deployment/preparation cannot complete
+    ///      (https://gist.github.com/Vectorized/846a474c855eee9e441506676800a9ad).
+    /// @dev This function is reentrancy safe.
+    ///
+    /// @return isValid True if signature is valid.
+    function isValidSignatureNow(address account, bytes32 hash, bytes calldata signature) public returns (bool) {
         return SignatureCheckerLib.isValidERC6492SignatureNow(account, hash, signature);
     }
 }

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -51,6 +51,9 @@ contract ApproveTest is SpendPermissionManagerBase {
         bytes memory extraData
     ) public {
         vm.assume(spender != address(0));
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
         vm.assume(start >= end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -95,7 +98,7 @@ contract ApproveTest is SpendPermissionManagerBase {
             extraData: extraData
         });
         vm.startPrank(account);
-        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidTokenZeroAddress.selector));
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroToken.selector));
         mockSpendPermissionManager.approve(spendPermission);
         vm.stopPrank();
     }
@@ -126,7 +129,7 @@ contract ApproveTest is SpendPermissionManagerBase {
             extraData: extraData
         });
         vm.startPrank(account);
-        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSpenderZeroAddress.selector));
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroSpender.selector));
         mockSpendPermissionManager.approve(spendPermission);
         vm.stopPrank();
     }
@@ -251,7 +254,6 @@ contract ApproveTest is SpendPermissionManagerBase {
         vm.expectEmit(address(mockSpendPermissionManager));
         emit SpendPermissionManager.SpendPermissionApproved({
             hash: mockSpendPermissionManager.getHash(spendPermission),
-            account: account,
             spendPermission: spendPermission
         });
         mockSpendPermissionManager.approve(spendPermission);

--- a/test/src/SpendPermissions/approveBatchWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveBatchWithSignature.t.sol
@@ -127,7 +127,7 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
 
         bytes memory stubSignature = abi.encodePacked("0x"); // can't get a valid signature for an empty batch because
             // getBatchHash reverts
-        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptyBatch.selector));
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptySpendPermissionBatch.selector));
         mockSpendPermissionManager.approveBatchWithSignature(spendPermissionBatch, stubSignature);
     }
 
@@ -234,7 +234,6 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
             vm.expectEmit(address(mockSpendPermissionManager));
             emit SpendPermissionManager.SpendPermissionApproved({
                 hash: mockSpendPermissionManager.getHash(expectedSpendPermissions[i]),
-                account: address(account),
                 spendPermission: expectedSpendPermissions[i]
             });
         }

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -54,6 +54,9 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         bytes memory extraData
     ) public {
         vm.assume(spender != address(0));
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
         vm.assume(start >= end);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
@@ -243,7 +246,6 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         vm.expectEmit(address(mockSpendPermissionManager));
         emit SpendPermissionManager.SpendPermissionApproved({
             hash: mockSpendPermissionManager.getHash(spendPermission),
-            account: address(account),
             spendPermission: spendPermission
         });
         mockSpendPermissionManager.approveWithSignature(spendPermission, signature);

--- a/test/src/SpendPermissions/getBatchHash.t.sol
+++ b/test/src/SpendPermissions/getBatchHash.t.sol
@@ -31,7 +31,7 @@ contract GetBatchHashTest is SpendPermissionManagerBase {
             period: period,
             permissions: permissions
         });
-        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptyBatch.selector));
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.EmptySpendPermissionBatch.selector));
         mockSpendPermissionManager.getBatchHash(spendPermissionBatch);
     }
 

--- a/test/src/SpendPermissions/revoke.t.sol
+++ b/test/src/SpendPermissions/revoke.t.sol
@@ -120,7 +120,6 @@ contract RevokeTest is SpendPermissionManagerBase {
         vm.expectEmit(address(mockSpendPermissionManager));
         emit SpendPermissionManager.SpendPermissionRevoked({
             hash: mockSpendPermissionManager.getHash(spendPermission),
-            account: account,
             spendPermission: spendPermission
         });
         mockSpendPermissionManager.revoke(spendPermission);

--- a/test/src/SpendPermissions/useSpendPermission.t.sol
+++ b/test/src/SpendPermissions/useSpendPermission.t.sol
@@ -183,48 +183,32 @@ contract UseSpendPermissionTest is SpendPermissionManagerBase {
     }
 
     function test_useSpendPermission_success_emitsEvent(
-        address account,
-        address spender,
-        uint48 start,
-        uint48 end,
-        uint48 period,
-        uint160 allowance,
-        uint160 spend,
-        uint256 salt,
-        bytes memory extraData
+        SpendPermissionManager.SpendPermission memory spendPermission,
+        uint160 spend
     ) public {
-        vm.assume(spender != address(0));
-        vm.assume(start > 0);
-        vm.assume(end > 0);
-        vm.assume(start < end);
-        vm.assume(period > 0);
-        vm.assume(allowance > 0);
+        vm.assume(spendPermission.spender != address(0));
+        vm.assume(spendPermission.start > 0);
+        vm.assume(spendPermission.end > 0);
+        vm.assume(spendPermission.start < spendPermission.end);
+        vm.assume(spendPermission.period > 0);
+        vm.assume(spendPermission.allowance > 0);
         vm.assume(spend > 0);
-        vm.assume(spend < allowance);
+        vm.assume(spend < spendPermission.allowance);
 
-        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
-            account: account,
-            spender: spender,
-            token: NATIVE_TOKEN,
-            start: start,
-            end: end,
-            period: period,
-            allowance: allowance,
-            salt: salt,
-            extraData: extraData
-        });
+        spendPermission.token = NATIVE_TOKEN;
 
-        vm.prank(account);
+        vm.prank(spendPermission.account);
         mockSpendPermissionManager.approve(spendPermission);
-        vm.warp(start);
+        vm.warp(spendPermission.start);
         vm.expectEmit(address(mockSpendPermissionManager));
         emit SpendPermissionManager.SpendPermissionUsed({
             hash: mockSpendPermissionManager.getHash(spendPermission),
-            account: account,
+            account: spendPermission.account,
+            spender: spendPermission.spender,
             token: NATIVE_TOKEN,
-            newUsage: SpendPermissionManager.PeriodSpend({
-                start: start,
-                end: _safeAddUint48(start, period, end),
+            periodSpend: SpendPermissionManager.PeriodSpend({
+                start: spendPermission.start,
+                end: _safeAddUint48(spendPermission.start, spendPermission.period, spendPermission.end),
                 spend: spend
             })
         });


### PR DESCRIPTION
Diff looks scarier than it is, but should do a thorough read regardless.

- reordered structs
- reordered main functions (approve, approveWithSignature, approveBatchWithSignature, spend, revoke)
- reordered errors with some renames
- updated events
  - removed `address indexed account` from approve/revoke events due to redundancy
  - added `address indexed spender` to used event to clarify recipient of funds, removed index on `token`
- updated comments
  - added callouts for reverts on view functions
  - update to style guide on 6492 validator
  - otherwise update nits on things that auditors may pick on for explicitness