### PR TITLE
Revert on failed spends

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -162,14 +162,6 @@ contract SpendPermissionManager is EIP712 {
     /// @param allowance Allowance value that was exceeded.
     error ExceededSpendPermission(uint256 value, uint256 allowance);
 
-    /// @notice External `IERC20.transferFrom` call did not return success when spending tokens.
-    ///
-    /// @param token Contract address for token.
-    /// @param account User address attempting to spend tokens from.
-    /// @param recipient Address attempting to send tokens to.
-    /// @param value Amount of tokens attempted to spend.
-    error ERC20TransferFailed(address token, address account, address recipient, uint256 value);
-
     /// @notice SpendPermission was approved via transaction.
     ///
     /// @param hash The unique hash representing the spend permission.

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -159,6 +159,14 @@ contract SpendPermissionManager is EIP712 {
     /// @param allowance Allowance value that was exceeded.
     error ExceededSpendPermission(uint256 value, uint256 allowance);
 
+    /// @notice External `IERC20.transferFrom` call did not return success when spending tokens.
+    ///
+    /// @param token Contract address for token.
+    /// @param account User address attempting to spend tokens from.
+    /// @param recipient Address attempting to send tokens to.
+    /// @param value Amount of tokens attempted to spend.
+    error ERC20TransferFailed(address token, address account, address recipient, uint256 value);
+
     /// @notice SpendPermission was approved via transaction.
     ///
     /// @param hash The unique hash representing the spend permission.
@@ -488,14 +496,22 @@ contract SpendPermissionManager is EIP712 {
         // transfer tokens from account to recipient
         if (token == NATIVE_TOKEN) {
             _execute({account: account, target: recipient, value: value, data: hex""});
-        } else {
+            return;
+        }
+        // set infinite allowance if not yet set
+        uint256 allowance = IERC20(token).allowance(account, address(this));
+        if (allowance != type(uint256).max) {
             _execute({
                 account: account,
                 target: token,
                 value: 0,
-                data: abi.encodeWithSelector(IERC20.transfer.selector, recipient, value)
+                data: abi.encodeWithSelector(IERC20.approve.selector, address(this), type(uint256).max)
             });
         }
+
+        // use ERC-20 allowance to transfer from account to recipient
+        bool success = IERC20(token).transferFrom(account, recipient, value);
+        if (!success) revert ERC20TransferFailed(token, account, recipient, value);
     }
 
     /// @notice Execute a single call on an account.

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC1271} from "openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
@@ -16,6 +17,8 @@ import {PublicERC6492Validator} from "./PublicERC6492Validator.sol";
 ///
 /// @author Coinbase (https://github.com/coinbase/spend-permissions)
 contract SpendPermissionManager is EIP712 {
+    using SafeERC20 for IERC20;
+
     /// @notice A spend permission for an external entity to be able to spend an account's tokens.
     struct SpendPermission {
         /// @dev Smart account this spend permission is valid for.
@@ -510,8 +513,8 @@ contract SpendPermissionManager is EIP712 {
         }
 
         // use ERC-20 allowance to transfer from account to recipient
-        bool success = IERC20(token).transferFrom(account, recipient, value);
-        if (!success) revert ERC20TransferFailed(token, account, recipient, value);
+        // safeTransferFrom will revert if transfer fails, regardless of ERC-20 implementation
+        IERC20(token).safeTransferFrom(account, recipient, value);
     }
 
     /// @notice Execute a single call on an account.

--- a/test/mocks/MockERC20MissingReturn.sol
+++ b/test/mocks/MockERC20MissingReturn.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {MockERC20} from "solady/../test/utils/mocks/MockERC20.sol";
+
+contract MockERC20MissingReturn is MockERC20 {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockERC20(name_, symbol_, decimals_) {}
+
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        super.transfer(to, amount); // ignore return value
+        assembly {
+            return(0, 0)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        super.transferFrom(from, to, amount); // ignore return value
+        assembly {
+            return(0, 0)
+        }
+    }
+}


### PR DESCRIPTION
Always revert if a spend fails to transfer tokens.  Previously, we would fail silently, leaving the burden of verification with the spender to ensure that funds moved as expected. This is confusing behavior that easily could have led to dangerous assumptions by spenders that their spends were successful when in fact they were not.