### PR TITLE
Restrict allowances in `_transferFrom`

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -568,7 +568,6 @@ contract SpendPermissionManager is EIP712 {
             value: 0,
             data: abi.encodeWithSelector(IERC20.approve.selector, address(this), value)
         });
-        }
 
         // use ERC-20 allowance to transfer from account to recipient
         // safeTransferFrom will revert if transfer fails, regardless of ERC-20 implementation

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -112,6 +112,15 @@ contract SpendPermissionManager is EIP712 {
     /// @notice Invalid signature.
     error InvalidSignature();
 
+    /// @notice Last updated period is different from the expected last updated period.
+    error InvalidLastUpdatedPeriod(PeriodSpend actualLastUpdatedPeriod, PeriodSpend expectedLastUpdatedPeriod);
+
+    /// @notice Mismatched accounts for spend permission.
+    ///
+    /// @param firstAccount First account in the spend permission.
+    /// @param secondAccount Second account in the spend permission.
+    error MismatchedAccounts(address firstAccount, address secondAccount);
+
     /// @notice Empty batch of spend permissions.
     error EmptySpendPermissionBatch();
 
@@ -282,15 +291,56 @@ contract SpendPermissionManager is EIP712 {
         _transferFrom(spendPermission.token, spendPermission.account, spendPermission.spender, value);
     }
 
+    /// @notice Approves a permission while revoking another if its last update has not changed.
+    ///
+    /// @dev Enforces that the last updated period of the permission being revoked matches the last valid updated period
+    ///      submitted as an argument. This is to prevent frontrunning `approveWithRevoke` with additional last-minute
+    /// spends.
+    /// @dev The `account` of the permissions must match, but the remaining fields can differ.
+    /// @dev Can only be called by the `account` of a permission.
+    ///
+    /// @param permissionToApprove Details of the spend permission to approve.
+    /// @param permissionToRevoke Details of the spend permission to revoke.
+    /// @param lastValidUpdatedPeriod Last valid updated period for the spend permission being revoked.
+    function approveWithRevoke(
+        SpendPermission calldata permissionToApprove,
+        SpendPermission calldata permissionToRevoke,
+        PeriodSpend calldata lastValidUpdatedPeriod
+    ) external requireSender(permissionToApprove.account) {
+        // require both spend permissions apply to the same account
+        if (permissionToApprove.account != permissionToRevoke.account) {
+            revert MismatchedAccounts(permissionToApprove.account, permissionToRevoke.account);
+        }
+        // validate that no spending has occurred since the last updated period passed to the function
+        PeriodSpend memory lastUpdatedPeriod = getLastUpdatedPeriod(permissionToRevoke);
+        if (
+            lastUpdatedPeriod.spend != lastValidUpdatedPeriod.spend
+                || lastUpdatedPeriod.start != lastValidUpdatedPeriod.start
+                || lastUpdatedPeriod.end != lastValidUpdatedPeriod.end
+        ) {
+            revert InvalidLastUpdatedPeriod(lastUpdatedPeriod, lastValidUpdatedPeriod);
+        }
+        // revoke old and approve new spend permissions
+        _revoke(permissionToRevoke);
+        _approve(permissionToApprove);
+    }
+
     /// @notice Revoke a spend permission to disable its use indefinitely.
     ///
     /// @dev Can only be called by the `account` of a permission.
     ///
     /// @param spendPermission Details of the spend permission.
     function revoke(SpendPermission calldata spendPermission) external requireSender(spendPermission.account) {
-        bytes32 hash = getHash(spendPermission);
-        _isRevoked[hash] = true;
-        emit SpendPermissionRevoked(hash, spendPermission);
+        _revoke(spendPermission);
+    }
+
+    /// @notice Revoke a spend permission to disable its use indefinitely.
+    ///
+    /// @dev Can only be called by the `spender` of a permission.
+    ///
+    /// @param spendPermission Details of the spend permission.
+    function spenderRevoke(SpendPermission calldata spendPermission) external requireSender(spendPermission.spender) {
+        _revoke(spendPermission);
     }
 
     /// @notice Hash a SpendPermission struct for signing in accordance with EIP-712
@@ -370,6 +420,15 @@ contract SpendPermissionManager is EIP712 {
         return !_isRevoked[hash] && _isApproved[hash];
     }
 
+    /// @notice Get last updated period for a spend permission.
+    ///
+    /// @param spendPermission Details of the spend permission.
+    ///
+    /// @return lastUpdatedPeriod Last updated period for the spend permission.
+    function getLastUpdatedPeriod(SpendPermission memory spendPermission) public view returns (PeriodSpend memory) {
+        return _lastUpdatedPeriod[getHash(spendPermission)];
+    }
+
     /// @notice Get start, end, and spend of the current period.
     ///
     /// @dev Reverts if spend permission has not started or has already ended.
@@ -443,6 +502,15 @@ contract SpendPermissionManager is EIP712 {
         emit SpendPermissionApproved(hash, spendPermission);
     }
 
+    /// @notice Revoke a spend permission.
+    ///
+    /// @param spendPermission Details of the spend permission.
+    function _revoke(SpendPermission memory spendPermission) internal {
+        bytes32 hash = getHash(spendPermission);
+        _isRevoked[hash] = true;
+        emit SpendPermissionRevoked(hash, spendPermission);
+    }
+
     /// @notice Use a spend permission.
     ///
     /// @param spendPermission Details of the spend permission.
@@ -481,7 +549,7 @@ contract SpendPermissionManager is EIP712 {
 
     /// @notice Transfer assets from an account to a recipient.
     ///
-    /// @dev Assumes ERC-20 contract will revert if transfer fails. If silently fails, spend still marked as used.
+    /// @dev Uses `safeTransferFrom` for ERC-20 tokens to enforce revert on failure.
     ///
     /// @param token Address of the token contract.
     /// @param account Address of the user account.
@@ -500,6 +568,7 @@ contract SpendPermissionManager is EIP712 {
             value: 0,
             data: abi.encodeWithSelector(IERC20.approve.selector, address(this), value)
         });
+        }
 
         // use ERC-20 allowance to transfer from account to recipient
         // safeTransferFrom will revert if transfer fails, regardless of ERC-20 implementation

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -7,6 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 import {ERC20} from "solady/../src/tokens/ERC20.sol";
 import {MockERC20} from "solady/../test/utils/mocks/MockERC20.sol";
+import {MockERC20LikeUSDT} from "solady/../test/utils/mocks/MockERC20LikeUSDT.sol";
 import {ReturnsFalseToken} from "solady/../test/utils/weird-tokens/ReturnsFalseToken.sol";
 
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
@@ -17,6 +18,7 @@ contract SpendTest is SpendPermissionManagerBase {
     MockERC20 mockERC20 = new MockERC20("mockERC20", "TEST", 18);
     ReturnsFalseToken mockERC20ReturnsFalse = new ReturnsFalseToken();
     MockERC20MissingReturn mockERC20MissingReturn = new MockERC20MissingReturn("mockERC20MissingReturn", "TEST", 18);
+    MockERC20LikeUSDT mockERC20LikeUSDT = new MockERC20LikeUSDT();
 
     function setUp() public {
         _initializeSpendPermissionManager();
@@ -286,6 +288,57 @@ contract SpendTest is SpendPermissionManagerBase {
         assertEq(usage.start, start);
         assertEq(usage.end, _safeAddUint48(start, period, end));
         assertEq(usage.spend, spend);
+    }
+
+    function test_spend_success_ERC20LikeUSDT(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 totalSpend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(spender != address(account)); // otherwise balance checks can fail
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(totalSpend > 1);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= totalSpend);
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: address(mockERC20LikeUSDT),
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        mockERC20LikeUSDT.mint(address(account), allowance);
+        vm.prank(address(account));
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.warp(start);
+        uint160 spend = totalSpend / 2; // allow two spends
+        assertEq(mockERC20LikeUSDT.balanceOf(address(account)), allowance);
+        assertEq(mockERC20LikeUSDT.balanceOf(spender), 0);
+        vm.startPrank(spender);
+        mockSpendPermissionManager.spend(spendPermission, spend);
+        assertEq(mockERC20LikeUSDT.balanceOf(address(account)), allowance - spend);
+        assertEq(mockERC20LikeUSDT.balanceOf(spender), spend);
+        SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
+        assertEq(usage.start, start);
+        assertEq(usage.end, _safeAddUint48(start, period, end));
+        assertEq(usage.spend, spend);
+        // Second spend should succeed as well. This fails if the approval behavior in
+        // `SpendPermissionManager._transferFrom` ever tries to
+        // approve USDT allowance when the existing allowance is nonzero.
+        mockSpendPermissionManager.spend(spendPermission, spend);
     }
 
     function test_spend_success_ERC20NoReturn(


### PR DESCRIPTION
BW-619

At the recommendation of internal protosec team, this PR restricts the size of allowances used in `_transferFrom` from infinite to the size of the spend immediately happening.  This improves security at the expense of slightly increased gas. Adds a test for USDT-type tokens, which revert when trying to set allowances if allowances are already nonzero. Since there is no legitimate reason for an account to independently set a nonzero allowance for the `SpendPermissionManager` contract, we skip the checking of whether an allowance is nonzero, and would leave it to the account to reset their allowance  to zero if necessary.