### PR TITLE
Clean up behavior of `_approve` and `_revoke`

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -216,8 +216,14 @@ contract SpendPermissionManager is EIP712 {
     /// @dev Can only be called by the `account` of a permission.
     ///
     /// @param spendPermission Details of the spend permission.
-    function approve(SpendPermission calldata spendPermission) external requireSender(spendPermission.account) {
-        _approve(spendPermission);
+    ///
+    /// @return approved True if spend permission is approved and not revoked.
+    function approve(SpendPermission calldata spendPermission)
+        external
+        requireSender(spendPermission.account)
+        returns (bool)
+    {
+        return _approve(spendPermission);
     }
 
     /// @notice Approve a spend permission via a signature from the account.
@@ -226,7 +232,12 @@ contract SpendPermissionManager is EIP712 {
     ///
     /// @param spendPermission Details of the spend permission.
     /// @param signature Signed approval from the user.
-    function approveWithSignature(SpendPermission calldata spendPermission, bytes calldata signature) external {
+    ///
+    /// @return approved True if spend permission is approved and not revoked.
+    function approveWithSignature(SpendPermission calldata spendPermission, bytes calldata signature)
+        external
+        returns (bool)
+    {
         // validate signature over spend permission data, deploying or preparing account if necessary
         if (
             !publicERC6492Validator.isValidSignatureNowAllowSideEffects(
@@ -235,8 +246,7 @@ contract SpendPermissionManager is EIP712 {
         ) {
             revert InvalidSignature();
         }
-
-        _approve(spendPermission);
+        return _approve(spendPermission);
     }
 
     /// @notice Approve a spend permission batch via a signature from the account.
@@ -246,8 +256,11 @@ contract SpendPermissionManager is EIP712 {
     ///
     /// @param spendPermissionBatch Details of the spend permission batch.
     /// @param signature Signed approval from the user.
+    ///
+    /// @return allApproved True if all spend permissions in the batch are approved and not revoked.
     function approveBatchWithSignature(SpendPermissionBatch memory spendPermissionBatch, bytes calldata signature)
         external
+        returns (bool)
     {
         // validate signature over spend permission batch data
         if (
@@ -259,22 +272,28 @@ contract SpendPermissionManager is EIP712 {
         }
 
         // loop through each spend permission in the batch and approve it
+        bool allApproved = true;
         uint256 batchLen = spendPermissionBatch.permissions.length;
         for (uint256 i; i < batchLen; i++) {
-            _approve(
-                SpendPermission({
-                    account: spendPermissionBatch.account,
-                    spender: spendPermissionBatch.permissions[i].spender,
-                    token: spendPermissionBatch.permissions[i].token,
-                    allowance: spendPermissionBatch.permissions[i].allowance,
-                    period: spendPermissionBatch.period,
-                    start: spendPermissionBatch.start,
-                    end: spendPermissionBatch.end,
-                    salt: spendPermissionBatch.permissions[i].salt,
-                    extraData: spendPermissionBatch.permissions[i].extraData
-                })
-            );
+            if (
+                !_approve(
+                    SpendPermission({
+                        account: spendPermissionBatch.account,
+                        spender: spendPermissionBatch.permissions[i].spender,
+                        token: spendPermissionBatch.permissions[i].token,
+                        allowance: spendPermissionBatch.permissions[i].allowance,
+                        period: spendPermissionBatch.period,
+                        start: spendPermissionBatch.start,
+                        end: spendPermissionBatch.end,
+                        salt: spendPermissionBatch.permissions[i].salt,
+                        extraData: spendPermissionBatch.permissions[i].extraData
+                    })
+                )
+            ) {
+                allApproved = false;
+            }
         }
+        return allApproved;
     }
 
     /// @notice Spend tokens using a spend permission, transferring them from `account` to `spender`.
@@ -302,11 +321,13 @@ contract SpendPermissionManager is EIP712 {
     /// @param permissionToApprove Details of the spend permission to approve.
     /// @param permissionToRevoke Details of the spend permission to revoke.
     /// @param lastValidUpdatedPeriod Last valid updated period for the spend permission being revoked.
+    ///
+    /// @return approved True if new spend permission is approved and not revoked.
     function approveWithRevoke(
         SpendPermission calldata permissionToApprove,
         SpendPermission calldata permissionToRevoke,
         PeriodSpend calldata lastValidUpdatedPeriod
-    ) external requireSender(permissionToApprove.account) {
+    ) external requireSender(permissionToApprove.account) returns (bool) {
         // require both spend permissions apply to the same account
         if (permissionToApprove.account != permissionToRevoke.account) {
             revert MismatchedAccounts(permissionToApprove.account, permissionToRevoke.account);
@@ -322,7 +343,7 @@ contract SpendPermissionManager is EIP712 {
         }
         // revoke old and approve new spend permissions
         _revoke(permissionToRevoke);
-        _approve(permissionToApprove);
+        return _approve(permissionToApprove);
     }
 
     /// @notice Revoke a spend permission to disable its use indefinitely.

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -357,7 +357,11 @@ contract ApproveTest is SpendPermissionManagerBase {
         });
         vm.startPrank(account);
         mockSpendPermissionManager.revoke(spendPermission); // revoke permission before approval
+        vm.recordLogs();
         bool approved = mockSpendPermissionManager.approve(spendPermission);
-        vm.assertFalse(approved);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 0); // no event emitted
+        vm.assertFalse(approved); // returns false
+        vm.assertFalse(mockSpendPermissionManager.isApproved(spendPermission)); // permission is not approved
     }
 }

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -5,6 +5,8 @@ import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
 
+import {Vm} from "forge-std/Test.sol";
+
 contract ApproveTest is SpendPermissionManagerBase {
     function setUp() public {
         _initializeSpendPermissionManager();
@@ -257,5 +259,105 @@ contract ApproveTest is SpendPermissionManagerBase {
             spendPermission: spendPermission
         });
         mockSpendPermissionManager.approve(spendPermission);
+    }
+
+    function test_approve_success_returnsTrue(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.prank(account);
+        bool approved = mockSpendPermissionManager.approve(spendPermission);
+        vm.assertTrue(approved);
+        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+    }
+
+    function test_approve_success_returnsTrueNoEventEmittedIfAlreadyApproved(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        mockSpendPermissionManager.approve(spendPermission); // approve permission before second approval
+        vm.recordLogs();
+        bool approved = mockSpendPermissionManager.approve(spendPermission);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 0); // no event emitted
+        vm.assertTrue(approved);
+        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+    }
+
+    function test_approve_success_returnsFalseIfPermissionRevoked(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        mockSpendPermissionManager.revoke(spendPermission); // revoke permission before approval
+        bool approved = mockSpendPermissionManager.approve(spendPermission);
+        vm.assertFalse(approved);
     }
 }

--- a/test/src/SpendPermissions/approveBatchWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveBatchWithSignature.t.sol
@@ -5,6 +5,8 @@ import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
 
+import {Vm} from "forge-std/Test.sol";
+
 contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
     function setUp() public {
         _initializeSpendPermissionManager();
@@ -281,7 +283,11 @@ contract ApproveBatchWithSignatureTest is SpendPermissionManagerBase {
         vm.prank(address(account));
         mockSpendPermissionManager.revoke(expectedSpendPermissions[0]); // preemptive revoke of first spend permission
         bytes memory signature = _signSpendPermissionBatch(spendPermissionBatch, ownerPk, 0);
+        vm.recordLogs();
+
         bool allApproved = mockSpendPermissionManager.approveBatchWithSignature(spendPermissionBatch, signature);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 1); // one approval event emitted
         vm.assertFalse(allApproved);
         vm.assertFalse(mockSpendPermissionManager.isApproved(expectedSpendPermissions[0]));
         vm.assertTrue(mockSpendPermissionManager.isApproved(expectedSpendPermissions[1]));

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -5,6 +5,8 @@ import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
 import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
 
+import {Vm} from "forge-std/Test.sol";
+
 contract ApproveWithSignatureTest is SpendPermissionManagerBase {
     function setUp() public {
         _initializeSpendPermissionManager();
@@ -198,6 +200,45 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         bool isApproved = mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
         vm.assertTrue(isApproved);
         vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+    }
+
+    function test_approveWithSignature_success_returnsFalseIfAlreadyRevoked(
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+
+        vm.prank(address(account));
+        mockSpendPermissionManager.revoke(spendPermission);
+        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
+        vm.recordLogs();
+        bool isApproved = mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 0);
+        vm.assertFalse(isApproved);
+        vm.assertFalse(mockSpendPermissionManager.isApproved(spendPermission));
     }
 
     function test_approveWithSignature_success_erc6492SignaturePreDeploy(

--- a/test/src/SpendPermissions/approveWithSignature.t.sol
+++ b/test/src/SpendPermissions/approveWithSignature.t.sol
@@ -166,6 +166,40 @@ contract ApproveWithSignatureTest is SpendPermissionManagerBase {
         vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
     }
 
+    function test_approveWithSignature_success_returnsTrue(
+        address spender,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(token != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+
+        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
+        bool isApproved = mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+        vm.assertTrue(isApproved);
+        vm.assertTrue(mockSpendPermissionManager.isApproved(spendPermission));
+    }
+
     function test_approveWithSignature_success_erc6492SignaturePreDeploy(
         uint128 ownerPk,
         address spender,

--- a/test/src/SpendPermissions/spend.t.sol
+++ b/test/src/SpendPermissions/spend.t.sol
@@ -154,6 +154,7 @@ contract SpendTest is SpendPermissionManagerBase {
         uint160 spend
     ) public {
         vm.assume(token.code.length == 0); // token is not deployed
+        assumeNotPrecompile(token);
         vm.assume(spender != address(0));
         vm.assume(spender != address(account)); // otherwise balance checks can fail
         vm.assume(start > 0);


### PR DESCRIPTION
We currently have no validation or differentiating behavior around actions such as approving or revoking already-approved or already-revoked spend permissions. We choose to avoid reverting during approvals or revocations to avoid inconvenient behavior in the case of race conditions or other possible scenarios in applying approvals/revokes that may be idempotent but are ultimately harmless if they succeed. However, we can use return values and the omission v.s. emission of events to offer more information about the behavior of various calls. The following changes will ensure a tidy event log, and provides more information about the effect of a call via its return that might be used by onchain spenders.  For example, a call to `_approve` will now return false (though not revert) if approving a spend permission that is already revoked and can therefore never truly be approved or used.

Events should only be emitted if the operation is not idempotent AND the intended effect takes place. 
- Otherwise, return early before event emission. 
- Return `true` for any operation for which the intended effect of the operation is indeed the state after applying the op, regardless of whether it was idempotent
- Return `false` if the operation’s intended effect is NOT the state after applying the operation.  The only case that falls into this category is an attempt to approve if the permission is already actually revoked.

Therefore we will behave in the following way for these cases:
_approve, if the spend permission has been already approved: Return true early, no event
_approve, if the spend permission has been already revoked: Return false early, no event
_revoke, if the spend permission has been already revoked: Return early, no event
_revoke, if the spend permission has not yet been approved: emit revoked event (fresh revoke)

batch approval should return false if any of the individual approvals returned false, true otherwise
approveWithRevoke should return false if the new permission being approved was already revoked, true otherwise
approveWithSignature should return false if the permission being approved is already revoked, true otherwise