### PR TITLE
Add MagicSpend capability to SpendPermissionManager

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -17,6 +17,7 @@ import {SpendPermissionManager} from "../src/SpendPermissionManager.sol";
  * $SEPOLIA_BASESCAN_API --etherscan-api-key $BASESCAN_API_KEY --broadcast -vvvv
  */
 contract Deploy is Script {
+    // https://github.com/coinbase/MagicSpend/releases/tag/v1.0.0
     address constant MAGIC_SPEND = 0x011A61C07DbF256A68256B1cB51A5e246730aB92;
 
     function run() public {

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -17,6 +17,8 @@ import {SpendPermissionManager} from "../src/SpendPermissionManager.sol";
  * $SEPOLIA_BASESCAN_API --etherscan-api-key $BASESCAN_API_KEY --broadcast -vvvv
  */
 contract Deploy is Script {
+    address constant MAGIC_SPEND = 0x011A61C07DbF256A68256B1cB51A5e246730aB92;
+
     function run() public {
         vm.startBroadcast();
 
@@ -27,7 +29,7 @@ contract Deploy is Script {
 
     function deploy() internal {
         PublicERC6492Validator publicERC6492Validator = new PublicERC6492Validator{salt: 0}();
-        new SpendPermissionManager{salt: 0}(publicERC6492Validator);
+        new SpendPermissionManager{salt: 0}(publicERC6492Validator, MAGIC_SPEND);
     }
 
     function logAddress(string memory name, address addr) internal pure {

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -82,7 +82,7 @@ contract SpendPermissionManager is EIP712 {
     ///         (https://eips.ethereum.org/EIPS/eip-6492).
     PublicERC6492Validator public immutable publicERC6492Validator;
 
-    /// @notice MagicSpend singleton (https://github.com/coinbase/MagicSpend).
+    /// @notice MagicSpend singleton (https://github.com/coinbase/magic-spend).
     address public immutable magicSpend;
 
     bytes32 public constant PERMISSION_TYPEHASH = keccak256(

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {SpendPermissionManager} from "../../src/SpendPermissionManager.sol";
-import {MockSpendPermissionManager} from "../mocks/MockSpendPermissionManager.sol";
-import {Base} from "./Base.sol";
-
-import {PublicERC6492Validator} from "../../src/PublicERC6492Validator.sol";
+import {MagicSpend} from "magic-spend/MagicSpend.sol";
 import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
 import {CoinbaseSmartWalletFactory} from "smart-wallet/CoinbaseSmartWalletFactory.sol";
+
+import {PublicERC6492Validator} from "../../src/PublicERC6492Validator.sol";
+import {SpendPermissionManager} from "../../src/SpendPermissionManager.sol";
+
+import {MockSpendPermissionManager} from "../mocks/MockSpendPermissionManager.sol";
+import {Base} from "./Base.sol";
 
 contract SpendPermissionManagerBase is Base {
     address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
@@ -15,6 +17,7 @@ contract SpendPermissionManagerBase is Base {
     bytes32 constant CBSW_MESSAGE_TYPEHASH = keccak256("CoinbaseSmartWalletMessage(bytes32 hash)");
 
     PublicERC6492Validator publicERC6492Validator;
+    MagicSpend magicSpend;
     MockSpendPermissionManager mockSpendPermissionManager;
     CoinbaseSmartWalletFactory mockCoinbaseSmartWalletFactory;
 
@@ -22,7 +25,8 @@ contract SpendPermissionManagerBase is Base {
         _initialize(); // Base
         mockCoinbaseSmartWalletFactory = new CoinbaseSmartWalletFactory(address(account));
         publicERC6492Validator = new PublicERC6492Validator();
-        mockSpendPermissionManager = new MockSpendPermissionManager(publicERC6492Validator);
+        magicSpend = new MagicSpend(owner, 1);
+        mockSpendPermissionManager = new MockSpendPermissionManager(publicERC6492Validator, address(magicSpend));
     }
 
     /**

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -138,6 +138,25 @@ contract SpendPermissionManagerBase is Base {
         return eip6492Signature;
     }
 
+    function _createWithdrawRequest() internal pure returns (MagicSpend.WithdrawRequest memory withdrawRequest) {
+        return MagicSpend.WithdrawRequest({
+            asset: address(0),
+            amount: 0,
+            nonce: 0,
+            expiry: type(uint48).max,
+            signature: hex""
+        });
+    }
+
+    function _signWithdrawRequest(address account, MagicSpend.WithdrawRequest memory withdrawRequest)
+        internal
+        view
+        returns (bytes memory signature)
+    {
+        bytes32 hash = magicSpend.getHash(account, withdrawRequest);
+        return _sign(ownerPk, hash);
+    }
+
     function _safeAddUint48(uint48 a, uint48 b, uint48 end) internal pure returns (uint48 c) {
         bool overflow = uint256(a) + uint256(b) > end;
         return overflow ? end : a + b;

--- a/test/mocks/MockSpendPermissionManager.sol
+++ b/test/mocks/MockSpendPermissionManager.sol
@@ -5,7 +5,9 @@ import {PublicERC6492Validator} from "../../src/PublicERC6492Validator.sol";
 import {SpendPermissionManager} from "../../src/SpendPermissionManager.sol";
 
 contract MockSpendPermissionManager is SpendPermissionManager {
-    constructor(PublicERC6492Validator _publicERC6492Validator) SpendPermissionManager(_publicERC6492Validator) {}
+    constructor(PublicERC6492Validator _publicERC6492Validator, address _magicSpend)
+        SpendPermissionManager(_publicERC6492Validator, magicSpend)
+    {}
 
     function useSpendPermission(SpendPermission memory spendPermission, uint256 value) public {
         _useSpendPermission(spendPermission, value);

--- a/test/mocks/MockSpendPermissionManager.sol
+++ b/test/mocks/MockSpendPermissionManager.sol
@@ -6,7 +6,7 @@ import {SpendPermissionManager} from "../../src/SpendPermissionManager.sol";
 
 contract MockSpendPermissionManager is SpendPermissionManager {
     constructor(PublicERC6492Validator _publicERC6492Validator, address _magicSpend)
-        SpendPermissionManager(_publicERC6492Validator, magicSpend)
+        SpendPermissionManager(_publicERC6492Validator, _magicSpend)
     {}
 
     function useSpendPermission(SpendPermission memory spendPermission, uint256 value) public {

--- a/test/src/SpendPermissions/getBatchHash.t.sol
+++ b/test/src/SpendPermissions/getBatchHash.t.sol
@@ -168,8 +168,10 @@ contract GetBatchHashTest is SpendPermissionManagerBase {
             period: period,
             permissions: permissions
         });
-        MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager(publicERC6492Validator);
-        MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager(publicERC6492Validator);
+        MockSpendPermissionManager mockSpendPermissionManager1 =
+            new MockSpendPermissionManager(publicERC6492Validator, address(magicSpend));
+        MockSpendPermissionManager mockSpendPermissionManager2 =
+            new MockSpendPermissionManager(publicERC6492Validator, address(magicSpend));
         bytes32 hash1 = mockSpendPermissionManager1.getBatchHash(spendPermissionBatch);
         bytes32 hash2 = mockSpendPermissionManager2.getBatchHash(spendPermissionBatch);
         assertNotEq(hash1, hash2);

--- a/test/src/SpendPermissions/getHash.t.sol
+++ b/test/src/SpendPermissions/getHash.t.sol
@@ -92,8 +92,10 @@ contract GetHashTest is SpendPermissionManagerBase {
             salt: salt,
             extraData: extraData
         });
-        MockSpendPermissionManager mockSpendPermissionManager1 = new MockSpendPermissionManager(publicERC6492Validator);
-        MockSpendPermissionManager mockSpendPermissionManager2 = new MockSpendPermissionManager(publicERC6492Validator);
+        MockSpendPermissionManager mockSpendPermissionManager1 =
+            new MockSpendPermissionManager(publicERC6492Validator, address(magicSpend));
+        MockSpendPermissionManager mockSpendPermissionManager2 =
+            new MockSpendPermissionManager(publicERC6492Validator, address(magicSpend));
         bytes32 hash1 = mockSpendPermissionManager1.getHash(spendPermission);
         bytes32 hash2 = mockSpendPermissionManager2.getHash(spendPermission);
         assertNotEq(hash1, hash2);

--- a/test/src/SpendPermissions/spendWithWithdraw.t.sol
+++ b/test/src/SpendPermissions/spendWithWithdraw.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.23;
 
 import {MagicSpend} from "magic-spend/MagicSpend.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ERC20} from "solady/../src/tokens/ERC20.sol";
 import {MockERC20} from "solady/../test/utils/mocks/MockERC20.sol";
 import {MockERC20LikeUSDT} from "solady/../test/utils/mocks/MockERC20LikeUSDT.sol";
 import {ReturnsFalseToken} from "solady/../test/utils/weird-tokens/ReturnsFalseToken.sol";
+import {ERC20} from "solady/tokens/ERC20.sol";
 
 import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
 
@@ -335,7 +335,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
         uint256 spenderBalance = address(spender).balance;
 
         vm.startPrank(spender);
-        vm.expectRevert(); // out of funds
+        vm.expectRevert(abi.encodeWithSelector(MagicSpend.WithdrawTooLarge.selector, spend, 0)); // no funds
         mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
 
         // assert spend not marked as used and balances unchanged
@@ -356,6 +356,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
     ) public {
         vm.assume(spender != address(0));
         vm.assume(spender != address(account)); // otherwise balance checks can fail
+        vm.assume(spender != address(magicSpend)); // otherwise balance checks can fail
         assumePayable(spender);
         vm.assume(start > 0);
         vm.assume(end > 0);
@@ -411,6 +412,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
     ) public {
         vm.assume(spender != address(0));
         vm.assume(spender != address(account)); // otherwise balance checks can fail
+        vm.assume(spender != address(magicSpend)); // otherwise balance checks can fail
         assumePayable(spender);
         vm.assume(start > 0);
         vm.assume(end > 0);

--- a/test/src/SpendPermissions/spendWithWithdraw.t.sol
+++ b/test/src/SpendPermissions/spendWithWithdraw.t.sol
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {MagicSpend} from "magic-spend/MagicSpend.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC20} from "solady/../src/tokens/ERC20.sol";
+import {MockERC20} from "solady/../test/utils/mocks/MockERC20.sol";
+import {MockERC20LikeUSDT} from "solady/../test/utils/mocks/MockERC20LikeUSDT.sol";
+import {ReturnsFalseToken} from "solady/../test/utils/weird-tokens/ReturnsFalseToken.sol";
+
+import {SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
+
+import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+import {MockERC20MissingReturn} from "../../mocks/MockERC20MissingReturn.sol";
+
+contract SpendWithWithdrawTest is SpendPermissionManagerBase {
+    MockERC20 mockERC20 = new MockERC20("mockERC20", "TEST", 18);
+    ReturnsFalseToken mockERC20ReturnsFalse = new ReturnsFalseToken();
+    MockERC20MissingReturn mockERC20MissingReturn = new MockERC20MissingReturn("mockERC20MissingReturn", "TEST", 18);
+    MockERC20LikeUSDT mockERC20LikeUSDT = new MockERC20LikeUSDT();
+
+    function setUp() public {
+        _initializeSpendPermissionManager();
+        vm.prank(owner);
+        account.addOwnerAddress(address(mockSpendPermissionManager));
+    }
+
+    function test_spendWithWithdraw_revert_invalidSender(
+        address sender,
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(sender != spender);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        vm.prank(account);
+        mockSpendPermissionManager.approve(spendPermission);
+        vm.startPrank(sender);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidSender.selector, sender, spender));
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_revert_nativeTokenWithdrawAssetMismatch(
+        uint128 invalidPk,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        address withdrawAsset
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(withdrawAsset != address(0));
+        uint160 spend = 0;
+        address spendToken = NATIVE_TOKEN;
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: spendToken,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.asset = withdrawAsset;
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.SpendTokenWithdrawAssetMismatch.selector, spendToken, withdrawAsset
+            )
+        );
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_revert_erc20TokenWithdrawAssetMismatch(
+        uint128 invalidPk,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        address spendToken,
+        address withdrawAsset
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(spendToken != NATIVE_TOKEN);
+        vm.assume(spendToken != withdrawAsset);
+        uint160 spend = 0;
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: spendToken,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.asset = withdrawAsset;
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.SpendTokenWithdrawAssetMismatch.selector, spendToken, withdrawAsset
+            )
+        );
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_revert_spendValueWithdrawAmountMismatch(
+        uint128 invalidPk,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        address spendToken,
+        uint160 spendValue,
+        uint256 withdrawAmount
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        vm.assume(spendToken != NATIVE_TOKEN);
+        vm.assume(spendValue != withdrawAmount);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: spendToken,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.asset = spendToken;
+        withdrawRequest.amount = withdrawAmount;
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SpendPermissionManager.SpendValueWithdrawAmountMismatch.selector, spendValue, withdrawAmount
+            )
+        );
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spendValue, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_revert_zeroValue(
+        uint128 invalidPk,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        uint160 spend = 0;
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroValue.selector));
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_revert_unauthorizedSpendPermission(
+        uint128 invalidPk,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(invalidPk != 0);
+        vm.assume(spender != address(0));
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.amount = spend;
+
+        vm.warp(start);
+        vm.startPrank(spender);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.UnauthorizedSpendPermission.selector));
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+        vm.stopPrank();
+    }
+
+    function test_spendWithWithdraw_reverts_magicSpendWithdrawFailed(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(spender != address(account)); // otherwise balance checks can fail
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+        address token = NATIVE_TOKEN;
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.amount = spend;
+        withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
+
+        vm.prank(address(account));
+        mockSpendPermissionManager.approve(spendPermission);
+
+        vm.warp(start);
+
+        uint256 accountBalance = address(account).balance;
+        uint256 spenderBalance = address(spender).balance;
+
+        vm.startPrank(spender);
+        vm.expectRevert(); // out of funds
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+
+        // assert spend not marked as used and balances unchanged
+        assertEq(mockSpendPermissionManager.getCurrentPeriod(spendPermission).spend, 0);
+        assertEq(address(account).balance, accountBalance);
+        assertEq(address(spender).balance, spenderBalance);
+    }
+
+    function test_spendWithWithdraw_success_ether(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(spender != address(account)); // otherwise balance checks can fail
+        assumePayable(spender);
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.amount = spend;
+        withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
+
+        vm.deal(address(magicSpend), allowance);
+
+        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
+
+        vm.warp(start);
+
+        vm.startPrank(spender);
+        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+
+        assertEq(address(magicSpend).balance, allowance - spend);
+        assertEq(address(account).balance, 0);
+        assertEq(spender.balance, spend);
+        SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
+        assertEq(usage.start, start);
+        assertEq(usage.end, _safeAddUint48(start, period, end));
+        assertEq(usage.spend, spend);
+    }
+
+    function test_spendWithWithdraw_success_erc20(
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData,
+        uint160 spend
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(spender != address(account)); // otherwise balance checks can fail
+        assumePayable(spender);
+        vm.assume(start > 0);
+        vm.assume(end > 0);
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(spend > 0);
+        vm.assume(allowance > 0);
+        vm.assume(allowance >= spend);
+
+        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
+            account: address(account),
+            spender: spender,
+            token: address(mockERC20),
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest();
+        withdrawRequest.asset = address(mockERC20);
+        withdrawRequest.amount = spend;
+        withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
+
+        mockERC20.mint(address(magicSpend), allowance);
+
+        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
+
+        vm.warp(start);
+
+        vm.startPrank(spender);
+        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
+        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
+
+        assertEq(mockERC20.balanceOf(address(magicSpend)), allowance - spend);
+        assertEq(mockERC20.balanceOf(address(account)), 0);
+        assertEq(mockERC20.balanceOf(spender), spend);
+        SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
+        assertEq(usage.start, start);
+        assertEq(usage.end, _safeAddUint48(start, period, end));
+        assertEq(usage.spend, spend);
+    }
+}


### PR DESCRIPTION
For a long time, we still expect most wallets to be insufficiently funded to approve spend permissions. Especially in cases where spending is expected consistently while the user is off-app (e.g. subscriptions), we would like to make it easier for users to not have to keep topping up a balance in their Smart Wallet. MagicSpend can help us address this problem by delegating the ability for an app to pull funds from users offchain accounts connected through MagicSpend.

We require 3 constraints for safe usage:
1. only approved spenders can trigger `MagicSpend.withdraw` from users account
2. spenders can only withdraw tokens they have approved by their permission
3. spenders can only withdraw up to their allowance value per-period

As a bonus, we also make spender-initiated withdraws atomic with the spender actually pulling funds all the way into itself through the account.

Note that all MagicSpend withdraw requests require a signature generated offchain by a trusted service. This service always maintains the ability to withhold signatures from apps that are acting malicious in any form. This also provides additional protections for users. More work is needed to expose a backend service for apps to request magic spend signatures for use with a spend permission.