### PR TITLE
Use hash of spend permission in `WithdrawRequest.nonce` to validate

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -105,7 +105,7 @@ contract SpendPermissionManager is EIP712 {
     bytes4 public constant ERC721_INTERFACE_ID = 0x80ac58cd;
 
     /// @notice Number of upper bits from spend permission hash to use in withdraw request nonce
-    uint256 public constant NONCE_HASH_BITS = 96; // Use 96 bits, leaving 160 bits in nonce for entropy
+    uint256 public constant NONCE_HASH_BITS = 128; // Use 128 bits, leaving 128 bits in nonce for entropy
 
     /// @notice A flag to indicate if the contract can receive native token transfers, and the expected amount.
     /// @dev Contract can only receive exactly the expected amount during the execution of `spend` for native tokens.

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -139,20 +139,17 @@ contract SpendPermissionManagerBase is Base {
         return eip6492Signature;
     }
 
-    function _createWithdrawRequest(SpendPermissionManager.SpendPermission memory spendPermission, uint256 nonceEntropy)
+    function _createWithdrawRequest(SpendPermissionManager.SpendPermission memory spendPermission, uint128 nonceEntropy)
         internal
         view
         returns (MagicSpend.WithdrawRequest memory withdrawRequest)
     {
         // Get the hash and extract the portion we want
         bytes32 permissionHash = mockSpendPermissionManager.getHash(spendPermission);
-        uint256 hashPortion = uint256(permissionHash) >> (256 - NONCE_HASH_BITS);
-
-        // Use remaining bits for actual entropy
-        uint256 entropyPortion = nonceEntropy & ((1 << (256 - NONCE_HASH_BITS)) - 1);
+        uint128 hashPortion = uint128(uint256(permissionHash));
 
         // Combine hash portion and entropy portion
-        uint256 nonce = (hashPortion << (256 - NONCE_HASH_BITS)) | entropyPortion;
+        uint256 nonce = (nonceEntropy << NONCE_HASH_BITS) | hashPortion;
 
         return MagicSpend.WithdrawRequest({
             asset: address(0),

--- a/test/base/SpendPermissionManagerBase.sol
+++ b/test/base/SpendPermissionManagerBase.sol
@@ -15,7 +15,7 @@ contract SpendPermissionManagerBase is Base {
     address constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     bytes32 constant EIP6492_MAGIC_VALUE = 0x6492649264926492649264926492649264926492649264926492649264926492;
     bytes32 constant CBSW_MESSAGE_TYPEHASH = keccak256("CoinbaseSmartWalletMessage(bytes32 hash)");
-    uint256 constant NONCE_HASH_BITS = 96;
+    uint256 constant NONCE_HASH_BITS = 128;
 
     PublicERC6492Validator publicERC6492Validator;
     MagicSpend magicSpend;

--- a/test/src/SpendPermissions/spendWithWithdraw.t.sol
+++ b/test/src/SpendPermissions/spendWithWithdraw.t.sol
@@ -68,7 +68,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.amount = spend;
 
         vm.prank(address(account));
@@ -100,7 +100,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.asset = withdrawAsset;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -137,7 +137,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.asset = withdrawAsset;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -175,7 +175,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
         });
 
         // Setup withdraw request for partial amount
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.asset = address(mockERC20);
         withdrawRequest.amount = params.allowance; // allowance is our withdrawAmount
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
@@ -223,7 +223,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.amount = params.allowance; // allowance is our withdrawAmount
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -272,7 +272,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             salt: salt,
             extraData: extraData
         });
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spender, entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, entropy);
         withdrawRequest.amount = spend;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -283,13 +283,11 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
         vm.stopPrank();
     }
 
-    function test_spendWithWithdraw_revert_invalidEncodedSpender(
+    function test_spendWithWithdraw_revert_invalidEncodedSpendPermissionHash(
         CommonTestParams memory params,
-        uint160 spend,
-        address encodedSpender
+        uint160 spend
     ) public {
         _validateCommonAssumptions(params);
-        vm.assume(encodedSpender != params.spender); // Ensure encoded spender is different
         vm.assume(spend > 0);
         vm.assume(params.allowance >= spend);
 
@@ -305,9 +303,22 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        // Create withdraw request with incorrect encoded spender
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(encodedSpender, params.entropy);
-        withdrawRequest.amount = spend;
+        // Get the correct hash portion first
+        bytes32 permissionHash = mockSpendPermissionManager.getHash(spendPermission);
+        uint256 correctHashPortion = uint256(permissionHash) >> (256 - NONCE_HASH_BITS);
+
+        // Create withdraw request with incorrect hash portion
+        uint256 incorrectHashPortion = correctHashPortion + 1; // Make it different
+        uint256 entropyPortion = params.entropy & ((1 << (256 - NONCE_HASH_BITS)) - 1);
+        uint256 incorrectNonce = (incorrectHashPortion << (256 - NONCE_HASH_BITS)) | entropyPortion;
+
+        MagicSpend.WithdrawRequest memory withdrawRequest = MagicSpend.WithdrawRequest({
+            asset: address(0),
+            amount: spend,
+            nonce: incorrectNonce,
+            expiry: type(uint48).max,
+            signature: hex""
+        });
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
         vm.deal(address(magicSpend), params.allowance);
@@ -321,7 +332,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                SpendPermissionManager.InvalidWithdrawRequestSpender.selector, encodedSpender, params.spender
+                SpendPermissionManager.InvalidWithdrawRequestHash.selector, incorrectHashPortion, correctHashPortion
             )
         );
         mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
@@ -347,7 +358,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.amount = spend;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -387,7 +398,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.amount = spend;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
@@ -431,7 +442,7 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
             extraData: params.extraData
         });
 
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
         withdrawRequest.asset = address(mockERC20);
         withdrawRequest.amount = spend;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
@@ -480,8 +491,8 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
         });
 
         // Setup withdraw request for partial amount
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
-        withdrawRequest.amount = params.allowance; // allowance is our withdrawAmount
+        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(spendPermission, params.entropy);
+        withdrawRequest.amount = params.allowance;
         withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
 
         // Setup initial balances
@@ -506,51 +517,5 @@ contract SpendWithWithdrawTest is SpendPermissionManagerBase {
         assertEq(usage.start, params.start);
         assertEq(usage.end, _safeAddUint48(params.start, params.period, params.end));
         assertEq(usage.spend, totalSpend);
-    }
-
-    function test_spendWithWithdraw_success_withEncodedSpender(CommonTestParams memory params, uint160 spend) public {
-        _validateCommonAssumptions(params);
-        assumePayable(params.spender);
-        vm.assume(spend > 0);
-        vm.assume(params.allowance >= spend);
-
-        SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
-            account: address(account),
-            spender: params.spender,
-            token: NATIVE_TOKEN,
-            start: params.start,
-            end: params.end,
-            period: params.period,
-            allowance: params.allowance,
-            salt: params.salt,
-            extraData: params.extraData
-        });
-
-        // Create withdraw request with correctly encoded spender
-        MagicSpend.WithdrawRequest memory withdrawRequest = _createWithdrawRequest(params.spender, params.entropy);
-        withdrawRequest.amount = spend;
-        withdrawRequest.signature = _signWithdrawRequest(address(account), withdrawRequest);
-
-        vm.deal(address(magicSpend), params.allowance);
-        vm.deal(address(account), 0);
-        vm.deal(params.spender, 0);
-
-        bytes memory signature = _signSpendPermission(spendPermission, ownerPk, 0);
-
-        vm.warp(params.start);
-
-        vm.startPrank(params.spender);
-        mockSpendPermissionManager.approveWithSignature(spendPermission, signature);
-        mockSpendPermissionManager.spendWithWithdraw(spendPermission, spend, withdrawRequest);
-
-        // Verify balances and state changes
-        assertEq(address(magicSpend).balance, params.allowance - spend);
-        assertEq(address(account).balance, 0);
-        assertEq(params.spender.balance, spend);
-        SpendPermissionManager.PeriodSpend memory usage = mockSpendPermissionManager.getCurrentPeriod(spendPermission);
-        assertEq(usage.start, params.start);
-        assertEq(usage.end, _safeAddUint48(params.start, params.period, params.end));
-        assertEq(usage.spend, spend);
-        vm.stopPrank();
     }
 }


### PR DESCRIPTION
Proposes the use of the spendpermission hash upper bits in the withdraw request nonce to restrict how any given withdraw request can be used and avoid the avenue for frontrunning withdraw requests that were obtained by other users. this creates tighter control than the original approach of encoding only the spender address.

