### PR TITLE
Use explicit `IERC_721` interface id

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -5,6 +5,7 @@ import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
 import {EIP712} from "solady/utils/EIP712.sol";
 import {IERC1271} from "openzeppelin-contracts/contracts/interfaces/IERC1271.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 import {MagicSpend} from "magic-spend/MagicSpend.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
@@ -102,7 +103,7 @@ contract SpendPermissionManager is EIP712 {
     address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @notice ERC-721 interface ID (https://eips.ethereum.org/EIPS/eip-721)
-    bytes4 public constant ERC721_INTERFACE_ID = 0x80ac58cd;
+    bytes4 public constant IERC721_INTERFACE_ID = type(IERC721).interfaceId;
 
     /// @notice A flag to indicate if the contract can receive native token transfers, and the expected amount.
     /// @dev Contract can only receive exactly the expected amount during the execution of `spend` for native tokens.
@@ -629,7 +630,7 @@ contract SpendPermissionManager is EIP712 {
         // check token is not an ERC-721
         if (spendPermission.token != NATIVE_TOKEN) {
             (bool success, bytes memory data) = spendPermission.token.staticcall(
-                abi.encodeWithSelector(IERC165.supportsInterface.selector, ERC721_INTERFACE_ID)
+                abi.encodeWithSelector(IERC165.supportsInterface.selector, IERC721_INTERFACE_ID)
             );
             if (success && data.length >= 32) {
                 bool isERC721 = abi.decode(data, (bool));

--- a/test/src/SpendPermissions/approve.t.sol
+++ b/test/src/SpendPermissions/approve.t.sol
@@ -391,7 +391,6 @@ contract ApproveTest is SpendPermissionManagerBase {
 
         // First verify our mock ERC721 actually supports the interface
         bool supported = IERC165(address(mockERC721)).supportsInterface(ERC721_INTERFACE_ID);
-        console2.log("Direct check - ERC721 supports interface:", supported);
 
         SpendPermissionManager.SpendPermission memory spendPermission = SpendPermissionManager.SpendPermission({
             account: account,


### PR DESCRIPTION
a more readable version of the interface id. use the exact form of the interface id [the OZ implementation uses](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6e05b68bd96ab90a4049adb89f20fd578404b274/contracts/token/ERC721/ERC721.sol#L47)