### PR TITLE
Add approveWithSenderAsAccount function

### DIFF
--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -126,6 +126,11 @@ contract SpendPermissionManager is EIP712 {
     /// @param sender Expected sender to be valid.
     error InvalidSender(address sender, address expected);
 
+    /// @notice Attempting to approve with null account, but account is non-null.
+    ///
+    /// @param account Expected account to be zero addresss.
+    error NonNullAccount(address account);
+
     /// @notice Token is an ERC-721, which is not supported to prevent NFT transfers
     /// @param token Address of the ERC-721 token contract
     error ERC721TokenNotSupported(address token);
@@ -277,6 +282,19 @@ contract SpendPermissionManager is EIP712 {
         requireSender(spendPermission.account)
         returns (bool)
     {
+        return _approve(spendPermission);
+    }
+
+    /// @notice Approve a spend permission with null account field to be set at sender.
+    ///
+    /// @dev Allows apps to request approvals via transaction without knowing account address.
+    ///
+    /// @param spendPermission Details of the spend permission.
+    ///
+    /// @return approved True if spend permission is approved and not revoked.
+    function approveWithNullAccount(SpendPermission memory spendPermission) external returns (bool) {
+        if (spendPermission.account != address(0)) revert NonNullAccount(spendPermission.account);
+        spendPermission.account = msg.sender;
         return _approve(spendPermission);
     }
 

--- a/src/SpendPermissionManager.sol
+++ b/src/SpendPermissionManager.sol
@@ -126,10 +126,10 @@ contract SpendPermissionManager is EIP712 {
     /// @param sender Expected sender to be valid.
     error InvalidSender(address sender, address expected);
 
-    /// @notice Attempting to approve with null account, but account is non-null.
+    /// @notice Attempting to approve with sender as account, but account argument is non-zero.
     ///
-    /// @param account Expected account to be zero addresss.
-    error NonNullAccount(address account);
+    /// @param account Invalid account expected to be zero addresss.
+    error NonZeroAccount(address account);
 
     /// @notice Token is an ERC-721, which is not supported to prevent NFT transfers
     /// @param token Address of the ERC-721 token contract
@@ -285,15 +285,16 @@ contract SpendPermissionManager is EIP712 {
         return _approve(spendPermission);
     }
 
-    /// @notice Approve a spend permission with null account field to be set at sender.
+    /// @notice Approve a spend permission with null account field to be set as call sender.
     ///
-    /// @dev Allows apps to request approvals via transaction without knowing account address.
+    /// @dev Convenience for apps to request approvals via transaction without knowing a user's account address.
+    /// @dev Replacing the spend permission's account as call sender will change its computed hash.
     ///
     /// @param spendPermission Details of the spend permission.
     ///
     /// @return approved True if spend permission is approved and not revoked.
-    function approveWithNullAccount(SpendPermission memory spendPermission) external returns (bool) {
-        if (spendPermission.account != address(0)) revert NonNullAccount(spendPermission.account);
+    function approveWithSenderAsAccount(SpendPermission memory spendPermission) external returns (bool) {
+        if (spendPermission.account != address(0)) revert NonZeroAccount(spendPermission.account);
         spendPermission.account = msg.sender;
         return _approve(spendPermission);
     }

--- a/test/src/SpendPermissions/approveWithNullAccount.t.sol
+++ b/test/src/SpendPermissions/approveWithNullAccount.t.sol
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {SpendPermission, SpendPermissionManager} from "../../../src/SpendPermissionManager.sol";
+
+import {SpendPermissionManagerBase} from "../../base/SpendPermissionManagerBase.sol";
+
+import {Vm, console2} from "forge-std/Test.sol";
+
+import {IERC165} from "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import {MockERC20} from "solady/../test/utils/mocks/MockERC20.sol";
+import {MockERC721} from "solady/../test/utils/mocks/MockERC721.sol";
+
+contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
+    MockERC721 mockERC721;
+    bytes4 public constant ERC721_INTERFACE_ID = 0x80ac58cd;
+
+    function setUp() public {
+        _initializeSpendPermissionManager();
+        mockERC721 = new MockERC721();
+    }
+
+    function test_approveWithNullAccount_revert_nonNullAccount(
+        address sender,
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(sender != address(0));
+        vm.assume(account != address(0));
+        vm.assume(sender != account);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+
+        vm.startPrank(sender);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.NonNullAccount.selector, account));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_revert_invalidStartEnd(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+        vm.assume(start >= end);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidStartEnd.selector, start, end));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_revert_invalidTokenZeroAddress(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: address(0),
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroToken.selector));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_revert_invalidSpenderZeroAddress(
+        address account,
+        address token,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        assumeNotPrecompile(token);
+        vm.assume(token != address(0));
+        vm.assume(start < end);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: address(0),
+            token: token,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroSpender.selector));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_revert_zeroPeriod(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: 0,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroPeriod.selector));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_revert_zeroAllowance(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: 0,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroAllowance.selector));
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+
+    function test_approveWithNullAccount_success_isAuthorized(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.prank(account);
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        spendPermission.account = account;
+        vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
+    }
+
+    function test_approveWithNullAccount_success_emitsEvent(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+
+        vm.startPrank(account);
+        vm.expectEmit(address(mockSpendPermissionManager));
+        emit SpendPermissionManager.SpendPermissionApproved({
+            hash: mockSpendPermissionManager.getHash(spendPermission),
+            spendPermission: spendPermission
+        });
+        spendPermission.account = address(0);
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+    }
+
+    function test_approveWithNullAccount_success_returnsTrue(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.prank(account);
+        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.assertTrue(approved);
+
+        spendPermission.account = account;
+        vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
+    }
+
+    function test_approveWithNullAccount_success_returnsTrueNoEventEmittedIfAlreadyApproved(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission); // approve permission before second approval
+        vm.recordLogs();
+        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 0); // no event emitted
+        vm.assertTrue(approved);
+
+        spendPermission.account = account;
+        vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
+    }
+
+    function test_approveWithNullAccount_success_returnsFalseIfPermissionRevoked(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: NATIVE_TOKEN,
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        vm.startPrank(account);
+        mockSpendPermissionManager.revoke(spendPermission); // revoke permission before approval
+
+        spendPermission.account = address(0);
+        vm.recordLogs();
+        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.assertEq(logs.length, 0); // no event emitted
+        vm.assertFalse(approved); // returns false
+
+        spendPermission.account = account;
+        vm.assertFalse(mockSpendPermissionManager.isValid(spendPermission)); // permission is not approved
+    }
+
+    function test_approveWithNullAccount_revert_erc721Token(
+        address account,
+        address spender,
+        uint48 start,
+        uint48 end,
+        uint48 period,
+        uint160 allowance,
+        uint256 salt,
+        bytes memory extraData
+    ) public {
+        vm.assume(account != address(0));
+        vm.assume(spender != address(0));
+        vm.assume(start < end);
+        vm.assume(period > 0);
+        vm.assume(allowance > 0);
+
+        // First verify our mock ERC721 actually supports the interface
+        bool supported = IERC165(address(mockERC721)).supportsInterface(ERC721_INTERFACE_ID);
+
+        SpendPermission memory spendPermission = SpendPermission({
+            account: account,
+            spender: spender,
+            token: address(mockERC721),
+            start: start,
+            end: end,
+            period: period,
+            allowance: allowance,
+            salt: salt,
+            extraData: extraData
+        });
+        spendPermission.account = address(0);
+
+        vm.startPrank(account);
+        vm.expectRevert(
+            abi.encodeWithSelector(SpendPermissionManager.ERC721TokenNotSupported.selector, address(mockERC721))
+        );
+        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.stopPrank();
+    }
+}

--- a/test/src/SpendPermissions/approveWithSenderAsAccount.t.sol
+++ b/test/src/SpendPermissions/approveWithSenderAsAccount.t.sol
@@ -20,7 +20,7 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         mockERC721 = new MockERC721();
     }
 
-    function test_approveWithNullAccount_revert_nonNullAccount(
+    function test_approveWithSenderAsAccount_revert_nonZeroAccount(
         address sender,
         address account,
         address spender,
@@ -48,12 +48,12 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         });
 
         vm.startPrank(sender);
-        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.NonNullAccount.selector, account));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.NonZeroAccount.selector, account));
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_revert_invalidStartEnd(
+    function test_approveWithSenderAsAccount_revert_invalidStartEnd(
         address account,
         address spender,
         uint48 start,
@@ -83,11 +83,11 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.InvalidStartEnd.selector, start, end));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_revert_invalidTokenZeroAddress(
+    function test_approveWithSenderAsAccount_revert_invalidTokenZeroAddress(
         address account,
         address spender,
         uint48 start,
@@ -115,11 +115,11 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroToken.selector));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_revert_invalidSpenderZeroAddress(
+    function test_approveWithSenderAsAccount_revert_invalidSpenderZeroAddress(
         address account,
         address token,
         uint48 start,
@@ -149,11 +149,11 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroSpender.selector));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_revert_zeroPeriod(
+    function test_approveWithSenderAsAccount_revert_zeroPeriod(
         address account,
         address spender,
         uint48 start,
@@ -180,11 +180,11 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroPeriod.selector));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_revert_zeroAllowance(
+    function test_approveWithSenderAsAccount_revert_zeroAllowance(
         address account,
         address spender,
         uint48 start,
@@ -212,11 +212,11 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         vm.startPrank(account);
         vm.expectRevert(abi.encodeWithSelector(SpendPermissionManager.ZeroAllowance.selector));
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 
-    function test_approveWithNullAccount_success_isAuthorized(
+    function test_approveWithSenderAsAccount_success_isAuthorized(
         address account,
         address spender,
         uint48 start,
@@ -246,12 +246,12 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         spendPermission.account = address(0);
 
         vm.prank(account);
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         spendPermission.account = account;
         vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
     }
 
-    function test_approveWithNullAccount_success_emitsEvent(
+    function test_approveWithSenderAsAccount_success_emitsEvent(
         address account,
         address spender,
         uint48 start,
@@ -286,10 +286,10 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
             spendPermission: spendPermission
         });
         spendPermission.account = address(0);
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
     }
 
-    function test_approveWithNullAccount_success_returnsTrue(
+    function test_approveWithSenderAsAccount_success_returnsTrue(
         address account,
         address spender,
         uint48 start,
@@ -319,14 +319,14 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         spendPermission.account = address(0);
 
         vm.prank(account);
-        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        bool approved = mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.assertTrue(approved);
 
         spendPermission.account = account;
         vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
     }
 
-    function test_approveWithNullAccount_success_returnsTrueNoEventEmittedIfAlreadyApproved(
+    function test_approveWithSenderAsAccount_success_returnsTrueNoEventEmittedIfAlreadyApproved(
         address account,
         address spender,
         uint48 start,
@@ -356,9 +356,10 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         spendPermission.account = address(0);
 
         vm.startPrank(account);
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission); // approve permission before second approval
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission); // approve permission before second
+            // approval
         vm.recordLogs();
-        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        bool approved = mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         vm.assertEq(logs.length, 0); // no event emitted
         vm.assertTrue(approved);
@@ -367,7 +368,7 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         vm.assertTrue(mockSpendPermissionManager.isValid(spendPermission));
     }
 
-    function test_approveWithNullAccount_success_returnsFalseIfPermissionRevoked(
+    function test_approveWithSenderAsAccount_success_returnsFalseIfPermissionRevoked(
         address account,
         address spender,
         uint48 start,
@@ -399,7 +400,7 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
 
         spendPermission.account = address(0);
         vm.recordLogs();
-        bool approved = mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        bool approved = mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         Vm.Log[] memory logs = vm.getRecordedLogs();
         vm.assertEq(logs.length, 0); // no event emitted
         vm.assertFalse(approved); // returns false
@@ -408,7 +409,7 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         vm.assertFalse(mockSpendPermissionManager.isValid(spendPermission)); // permission is not approved
     }
 
-    function test_approveWithNullAccount_revert_erc721Token(
+    function test_approveWithSenderAsAccount_revert_erc721Token(
         address account,
         address spender,
         uint48 start,
@@ -444,7 +445,7 @@ contract ApproveWithNullAccountTest is SpendPermissionManagerBase {
         vm.expectRevert(
             abi.encodeWithSelector(SpendPermissionManager.ERC721TokenNotSupported.selector, address(mockERC721))
         );
-        mockSpendPermissionManager.approveWithNullAccount(spendPermission);
+        mockSpendPermissionManager.approveWithSenderAsAccount(spendPermission);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
Requested add-on for convenience for integrating with commerce use cases that want to avoid reliance on `eth_requestAccounts`. Uncertain if we actually should include this addition, but implemented ready-to-review draft just in case.